### PR TITLE
Add evidence-gathering workflows

### DIFF
--- a/workflows/workflow-7ffc2c4d-9b41-481f-8e94-4aac697e70e3.yaml
+++ b/workflows/workflow-7ffc2c4d-9b41-481f-8e94-4aac697e70e3.yaml
@@ -1,0 +1,20 @@
+id: 7ffc2c4d-9b41-481f-8e94-4aac697e70e3
+name: gather-all-evidence
+description: Gather all rave-swamp evidence in parallel — one job per evidence model instance
+tags: {}
+jobs:
+  - name: ci-test-results
+    description: Gather CI test results evidence
+    steps:
+      - name: fetch
+        description: Fetch latest validate.yml run result
+        task:
+          type: model_method
+          modelIdOrName: evidence-ci-test-results-001
+          methodName: gather
+          inputs:
+            githubToken: ${{ vault.get(rave-credentials, GITHUB_TOKEN) }}
+        allowFailure: true
+    dependsOn: []
+    weight: 0
+version: 1

--- a/workflows/workflow-a2db8cf9-9b49-4abc-89d7-7ee4e0c1996b.yaml
+++ b/workflows/workflow-a2db8cf9-9b49-4abc-89d7-7ee4e0c1996b.yaml
@@ -1,0 +1,27 @@
+id: a2db8cf9-9b49-4abc-89d7-7ee4e0c1996b
+name: gather-prometheus-evidence
+description: Execute a PromQL query for a rave/prometheus-evidence model instance and record the result
+tags: {}
+inputs:
+  properties:
+    evidenceModelName:
+      type: string
+      description: Swamp model name for the rave/prometheus-evidence instance to gather
+  required:
+    - evidenceModelName
+jobs:
+  - name: gather
+    description: Run the gather method on the specified prometheus-evidence model
+    steps:
+      - name: fetch
+        description: Execute PromQL query and write result resource
+        task:
+          type: model_method
+          modelIdOrName: ${{ inputs.evidenceModelName }}
+          methodName: gather
+          inputs:
+            prometheusToken: ${{ vault.get(rave-credentials, PROMETHEUS_TOKEN) }}
+        allowFailure: false
+    dependsOn: []
+    weight: 0
+version: 1

--- a/workflows/workflow-f4d3a467-2c65-4732-a06f-291d01ff7e8c.yaml
+++ b/workflows/workflow-f4d3a467-2c65-4732-a06f-291d01ff7e8c.yaml
@@ -1,0 +1,27 @@
+id: f4d3a467-2c65-4732-a06f-291d01ff7e8c
+name: gather-ci-evidence
+description: Fetch the latest GitHub Actions CI run result for a rave/ci-evidence model instance
+tags: {}
+inputs:
+  properties:
+    evidenceModelName:
+      type: string
+      description: Swamp model name for the rave/ci-evidence instance to gather
+  required:
+    - evidenceModelName
+jobs:
+  - name: gather
+    description: Run the gather method on the specified ci-evidence model
+    steps:
+      - name: fetch
+        description: Fetch latest CI run and write result resource
+        task:
+          type: model_method
+          modelIdOrName: ${{ inputs.evidenceModelName }}
+          methodName: gather
+          inputs:
+            githubToken: ${{ vault.get(rave-credentials, GITHUB_TOKEN) }}
+        allowFailure: false
+    dependsOn: []
+    weight: 0
+version: 1


### PR DESCRIPTION
## Summary
- Adds 3 swamp workflows for evidence gathering:
  - **`gather-ci-evidence`** — parameterised by model name, calls `gather` with `GITHUB_TOKEN` from vault
  - **`gather-prometheus-evidence`** — parameterised by model name, calls `gather` with `PROMETHEUS_TOKEN` from vault
  - **`gather-all-evidence`** — parallel jobs for all rave-swamp evidence instances with `allowFailure: true`
- All three pass `swamp workflow validate`

## Test plan
- [ ] `swamp workflow validate --json` — all three pass ✓ (verified locally)
- [ ] `swamp model method run evidence-ci-test-results-001 gather` with vault token → data written ✓ (verified locally, outcome=inconclusive as validate.yml not yet created)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)