### PR TITLE
Add rave/claim extension model and USAGE.md

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,249 @@
+# rave-swamp Usage Guide
+
+RAVE claims and evidence are managed through a combination of:
+- **YAML files** in `rave/` — source of truth for entity configuration (versioned in git)
+- **swamp model data** — runtime state (confidence scores, evidence results, evaluation history)
+
+All changes to YAML files must go through a PR (branch protection is enforced).
+
+---
+
+## Claims
+
+### Create a claim
+
+```bash
+# 1. Create the swamp model instance
+swamp model create rave/claim claim-<id> --global-arg claimId=claim-<id>
+
+# 2. Write the claim YAML (creates rave/claims/claim-<id>.yaml)
+swamp model method run claim-<id> create \
+  --input '{
+    "statement": "Your claim statement here",
+    "owner": "your-name",
+    "contact": "#your-slack-channel",
+    "category": "reliability",
+    "scopeType": "repository",
+    "scopeTarget": "mesgme/rave-swamp",
+    "decayLambda": "0.05",
+    "assumptions": ["Assumption one", "Assumption two"],
+    "falsificationSignals": ["Signal that would disprove this"]
+  }'
+
+# 3. Create the confidence engine instance (one per claim)
+swamp model create rave/confidence-engine confidence-<id> \
+  --global-arg claimId=claim-<id> \
+  --global-arg decayLambda=0.05
+
+# 4. Commit via PR (status starts as "draft")
+git checkout -b feature/add-claim-<id>
+git add rave/claims/claim-<id>.yaml models/
+git commit -m "Add claim-<id>"
+git push -u origin feature/add-claim-<id>
+gh pr create
+```
+
+**Category values:** `reliability`, `change_risk`, `security`, `observability`, `compliance`
+
+**Scope types:** `repository`, `pipeline`, `component`
+
+---
+
+### Read a claim
+
+```bash
+# View the claim definition
+cat rave/claims/claim-<id>.yaml
+
+# Check current confidence score and history
+swamp data list confidence-<id>
+
+# Read the latest confidence snapshot (full detail)
+swamp data get confidence-<id> confidence --json
+```
+
+**Example — `claim-branch-protection-001`:**
+
+```bash
+cat rave/claims/claim-branch-protection-001.yaml
+swamp data list confidence-claim-branch-protection-001
+```
+
+---
+
+### Update a claim
+
+**Change metadata (statement, assumptions, decay lambda):**
+
+Edit `rave/claims/<id>.yaml` directly, then commit via PR.
+
+**Formally re-attest confidence** (reset the decay anchor):
+
+```bash
+swamp model method run confidence-<id> revalidate \
+  --input '{"newScore": 0.85, "revalidatedBy": "your-name"}'
+```
+
+**Add an annotation:**
+
+```bash
+swamp model method run claim-<id> annotate \
+  --input '{"text": "Validated in Q1 review. No issues found.", "author": "your-name"}'
+```
+
+The annotation is written directly to the claim YAML — commit the change via PR.
+
+**Activate a draft claim** (once evidence is wired up):
+
+```bash
+swamp model method run claim-<id> activate
+git add rave/claims/claim-<id>.yaml && git commit -m "Activate claim-<id>"
+```
+
+---
+
+### Change claim status
+
+| Target status | Command |
+|---|---|
+| `active` | `swamp model method run claim-<id> activate` |
+| `retired` | `swamp model method run claim-<id> retire --input '{"reason": "..."}'` |
+| `contradicted` | `swamp model method run claim-<id> contradict --input '{"reason": "..."}'` |
+
+Status effects on confidence scoring:
+- `draft` → score = 0.0 (not yet active)
+- `active` → score computed from evidence and decay
+- `retired` → score frozen at last value
+- `contradicted` → score = 0.0
+
+All status changes write to the YAML — commit via PR.
+
+---
+
+### Delete a claim
+
+```bash
+# 1. Remove the YAML
+rm rave/claims/claim-<id>.yaml
+
+# 2. Delete the claim model instance (--force required if data exists)
+swamp model delete claim-<id> --force
+
+# 3. Delete the confidence engine instance
+swamp model delete confidence-<id> --force
+
+# 4. Remove any linked falsifiers
+rm rave/falsifiers/falsifier-*-<id>-*.yaml          # if any exist
+swamp model delete falsifier-*-<id>-* --force        # if any exist
+
+# 5. Commit via PR
+git add -u && git commit -m "Remove claim-<id>"
+```
+
+---
+
+## Evidence
+
+### Gather evidence manually
+
+```bash
+# Gather CI evidence for a specific model
+swamp workflow run gather-ci-evidence \
+  --input '{"evidenceModelName": "evidence-ci-test-results-001"}'
+
+# Gather GitHub API evidence
+swamp model method run evidence-github-branch-protection-001 gather \
+  --input "{\"githubToken\": \"$(gh auth token)\"}"
+
+# Gather all evidence at once (parallel jobs, allowFailure)
+swamp workflow run gather-all-evidence
+```
+
+### Check evidence results
+
+```bash
+swamp data list evidence-ci-test-results-001
+swamp data list evidence-github-branch-protection-001
+swamp data list evidence-github-actions-runs-001
+```
+
+---
+
+## Confidence Scores
+
+### Compute confidence for a claim
+
+```bash
+# Pass current evidence results as inputs
+swamp model method run confidence-claim-branch-protection-001 compute \
+  --input '{
+    "currentScore": 0.82,
+    "lastValidated": "2026-03-20T00:00:00Z",
+    "currentStatus": "active",
+    "evidence": [{
+      "evidenceId": "evidence-github-branch-protection-001",
+      "outcome": "pass",
+      "timestamp": "2026-03-22T08:18:54Z",
+      "freshnessWindow": "PT1H",
+      "qualityScore": 1.0
+    }]
+  }'
+```
+
+### Read confidence history
+
+```bash
+swamp data list confidence-claim-branch-protection-001
+```
+
+---
+
+## Falsifiers
+
+### Evaluate a falsifier
+
+```bash
+# Check whether branch protection has been removed
+swamp model method run falsifier-branch-protection-missing-001 evaluate \
+  --input '{
+    "evidence": [{
+      "evidenceId": "evidence-github-branch-protection-001",
+      "outcome": "pass",
+      "timestamp": "2026-03-22T08:18:54Z",
+      "freshnessWindow": "PT1H",
+      "value": null,
+      "rawData": "<JSON from evidence result>"
+    }]
+  }'
+```
+
+### Check falsifier history
+
+```bash
+swamp data list falsifier-branch-protection-missing-001
+```
+
+---
+
+## Naming Conventions
+
+| Entity | File | Model instance |
+|---|---|---|
+| Claim | `rave/claims/claim-<id>.yaml` | `claim-<id>` (rave/claim) |
+| Confidence engine | — | `confidence-<claim-id>` (rave/confidence-engine) |
+| CI evidence | `rave/evidence/evidence-<id>.yaml` | `evidence-<id>` (rave/ci-evidence) |
+| GitHub API evidence | `rave/evidence/evidence-<id>.yaml` | `evidence-<id>` (rave/github-api-evidence) |
+| Falsifier | `rave/falsifiers/falsifier-<id>.yaml` | `falsifier-<id>` (rave/falsifier-engine) |
+
+---
+
+## All available model types
+
+| Type | Purpose |
+|---|---|
+| `rave/claim` | CRUD operations on claim YAML files |
+| `rave/confidence-engine` | Compute and track confidence scores |
+| `rave/ci-evidence` | Gather evidence from GitHub Actions workflow runs |
+| `rave/github-api-evidence` | Gather evidence from GitHub REST API endpoints |
+| `rave/prometheus-evidence` | Gather evidence from Prometheus/Thanos/VictoriaMetrics |
+| `rave/falsifier-engine` | Evaluate falsifier conditions against evidence |

--- a/extensions/models/rave_claim.ts
+++ b/extensions/models/rave_claim.ts
@@ -1,0 +1,275 @@
+import { z } from "npm:zod@4";
+import * as YAML from "npm:yaml@2";
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+const GlobalArgsSchema = z.object({
+  claimId: z.string(),
+});
+
+const ClaimStateSchema = z.object({
+  claimId: z.string(),
+  status: z.string(),
+  statement: z.string(),
+  category: z.string(),
+  updatedAt: z.string(),
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function claimsPath(repoDir: string, claimId: string): string {
+  return `${repoDir}/rave/claims/${claimId}.yaml`;
+}
+
+async function readClaim(path: string): Promise<Record<string, unknown>> {
+  const text = await Deno.readTextFile(path);
+  return YAML.parse(text) as Record<string, unknown>;
+}
+
+async function writeClaim(path: string, data: Record<string, unknown>): Promise<void> {
+  const text = YAML.stringify(data, { lineWidth: 0 });
+  await Deno.writeTextFile(path, text);
+}
+
+function nowISO(): string {
+  return new Date().toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// Model
+// ---------------------------------------------------------------------------
+
+export const model = {
+  type: "rave/claim",
+  version: "2026.03.22.1",
+  globalArguments: GlobalArgsSchema,
+  resources: {
+    state: {
+      description: "Current claim state snapshot (mirrors key fields from the YAML)",
+      schema: ClaimStateSchema,
+      lifetime: "infinite",
+      garbageCollection: 100,
+    },
+  },
+  methods: {
+    create: {
+      description: "Write a new claim YAML to rave/claims/ and record its initial state",
+      arguments: z.object({
+        statement: z.string(),
+        owner: z.string(),
+        team: z.string().optional(),
+        contact: z.string().optional(),
+        category: z.string(),
+        scopeType: z.string(),
+        scopeTarget: z.string(),
+        decayLambda: z.coerce.number().default(0.05),
+        assumptions: z.array(z.string()).default([]),
+        falsificationSignals: z.array(z.string()).default([]),
+      }),
+      execute: async (args, context) => {
+        const { claimId } = context.globalArgs;
+        const path = claimsPath(context.repoDir, claimId);
+
+        // Refuse to overwrite an existing claim
+        try {
+          await Deno.stat(path);
+          throw new Error(`Claim '${claimId}' already exists at ${path} — use update methods instead`);
+        } catch (err) {
+          if (!(err instanceof Deno.errors.NotFound)) throw err;
+        }
+
+        const owner: Record<string, unknown> = { name: args.owner };
+        if (args.team) owner.team = args.team;
+        if (args.contact) owner.contact = args.contact;
+
+        const claim: Record<string, unknown> = {
+          claim_id: claimId,
+          statement: args.statement,
+          owner,
+          status: "draft",
+          category: args.category,
+          scope: { type: args.scopeType, target: args.scopeTarget },
+          decay_lambda: args.decayLambda,
+          assumptions: args.assumptions,
+          falsification_signals: args.falsificationSignals,
+          annotations: [],
+        };
+
+        await writeClaim(path, claim);
+        context.logger.info(`Created claim '${claimId}' at ${path} (status=draft)`);
+
+        const handle = await context.writeResource("state", "current", {
+          claimId,
+          status: "draft",
+          statement: args.statement,
+          category: args.category,
+          updatedAt: nowISO(),
+        });
+
+        return { dataHandles: [handle] };
+      },
+    },
+
+    get: {
+      description: "Read the current claim YAML and record a state snapshot",
+      arguments: z.object({}),
+      execute: async (args, context) => {
+        const { claimId } = context.globalArgs;
+        const path = claimsPath(context.repoDir, claimId);
+        const claim = await readClaim(path);
+
+        context.logger.info(
+          `Claim '${claimId}': status=${claim.status} category=${claim.category}`,
+        );
+
+        const handle = await context.writeResource("state", "current", {
+          claimId,
+          status: String(claim.status ?? "unknown"),
+          statement: String(claim.statement ?? ""),
+          category: String(claim.category ?? ""),
+          updatedAt: nowISO(),
+        });
+
+        return { dataHandles: [handle] };
+      },
+    },
+
+    activate: {
+      description: "Set claim status to 'active' — use once evidence is wired up",
+      arguments: z.object({}),
+      execute: async (args, context) => {
+        const { claimId } = context.globalArgs;
+        const path = claimsPath(context.repoDir, claimId);
+        const claim = await readClaim(path);
+
+        const prev = String(claim.status);
+        claim.status = "active";
+        await writeClaim(path, claim);
+
+        context.logger.info(`Claim '${claimId}': ${prev} → active`);
+
+        const handle = await context.writeResource("state", "current", {
+          claimId,
+          status: "active",
+          statement: String(claim.statement ?? ""),
+          category: String(claim.category ?? ""),
+          updatedAt: nowISO(),
+        });
+
+        return { dataHandles: [handle] };
+      },
+    },
+
+    retire: {
+      description: "Set claim status to 'retired' — freezes the confidence score",
+      arguments: z.object({
+        reason: z.string().optional(),
+      }),
+      execute: async (args, context) => {
+        const { claimId } = context.globalArgs;
+        const path = claimsPath(context.repoDir, claimId);
+        const claim = await readClaim(path);
+
+        const prev = String(claim.status);
+        claim.status = "retired";
+
+        if (args.reason) {
+          const annotations = (claim.annotations as unknown[]) ?? [];
+          annotations.push({
+            text: `Retired: ${args.reason}`,
+            author: "rave/claim",
+            created_at: nowISO(),
+          });
+          claim.annotations = annotations;
+        }
+
+        await writeClaim(path, claim);
+        context.logger.info(`Claim '${claimId}': ${prev} → retired`);
+
+        const handle = await context.writeResource("state", "current", {
+          claimId,
+          status: "retired",
+          statement: String(claim.statement ?? ""),
+          category: String(claim.category ?? ""),
+          updatedAt: nowISO(),
+        });
+
+        return { dataHandles: [handle] };
+      },
+    },
+
+    contradict: {
+      description: "Set claim status to 'contradicted' — collapses confidence to 0",
+      arguments: z.object({
+        reason: z.string(),
+      }),
+      execute: async (args, context) => {
+        const { claimId } = context.globalArgs;
+        const path = claimsPath(context.repoDir, claimId);
+        const claim = await readClaim(path);
+
+        const prev = String(claim.status);
+        claim.status = "contradicted";
+
+        const annotations = (claim.annotations as unknown[]) ?? [];
+        annotations.push({
+          text: `Contradicted: ${args.reason}`,
+          author: "rave/claim",
+          created_at: nowISO(),
+        });
+        claim.annotations = annotations;
+
+        await writeClaim(path, claim);
+        context.logger.warn(`Claim '${claimId}': ${prev} → contradicted — ${args.reason}`);
+
+        const handle = await context.writeResource("state", "current", {
+          claimId,
+          status: "contradicted",
+          statement: String(claim.statement ?? ""),
+          category: String(claim.category ?? ""),
+          updatedAt: nowISO(),
+        });
+
+        return { dataHandles: [handle] };
+      },
+    },
+
+    annotate: {
+      description: "Add a free-text annotation to the claim YAML",
+      arguments: z.object({
+        text: z.string(),
+        author: z.string(),
+      }),
+      execute: async (args, context) => {
+        const { claimId } = context.globalArgs;
+        const path = claimsPath(context.repoDir, claimId);
+        const claim = await readClaim(path);
+
+        const annotations = (claim.annotations as unknown[]) ?? [];
+        annotations.push({
+          text: args.text,
+          author: args.author,
+          created_at: nowISO(),
+        });
+        claim.annotations = annotations;
+
+        await writeClaim(path, claim);
+        context.logger.info(`Claim '${claimId}': annotation added by '${args.author}'`);
+
+        const handle = await context.writeResource("state", "current", {
+          claimId,
+          status: String(claim.status ?? "unknown"),
+          statement: String(claim.statement ?? ""),
+          category: String(claim.category ?? ""),
+          updatedAt: nowISO(),
+        });
+
+        return { dataHandles: [handle] };
+      },
+    },
+  },
+};

--- a/models/rave/claim/12805140-43a8-4f2f-8ea1-56b8637dd13a.yaml
+++ b/models/rave/claim/12805140-43a8-4f2f-8ea1-56b8637dd13a.yaml
@@ -1,0 +1,9 @@
+type: rave/claim
+typeVersion: 2026.03.22.1
+id: 12805140-43a8-4f2f-8ea1-56b8637dd13a
+name: claim-swamp-models-valid-001
+version: 1
+tags: {}
+globalArguments:
+  claimId: claim-swamp-models-valid-001
+methods: {}

--- a/models/rave/claim/2b9894f0-2d8f-4557-bb41-e92871edbb01.yaml
+++ b/models/rave/claim/2b9894f0-2d8f-4557-bb41-e92871edbb01.yaml
@@ -1,0 +1,9 @@
+type: rave/claim
+typeVersion: 2026.03.22.1
+id: 2b9894f0-2d8f-4557-bb41-e92871edbb01
+name: claim-ci-green-on-main-001
+version: 1
+tags: {}
+globalArguments:
+  claimId: claim-ci-green-on-main-001
+methods: {}

--- a/models/rave/claim/659c2760-1af8-4ef1-b299-d41c0f4d9779.yaml
+++ b/models/rave/claim/659c2760-1af8-4ef1-b299-d41c0f4d9779.yaml
@@ -1,0 +1,9 @@
+type: rave/claim
+typeVersion: 2026.03.22.1
+id: 659c2760-1af8-4ef1-b299-d41c0f4d9779
+name: claim-swamp-workflows-valid-001
+version: 1
+tags: {}
+globalArguments:
+  claimId: claim-swamp-workflows-valid-001
+methods: {}

--- a/models/rave/claim/a4d7aeee-cacb-480d-bb13-0571cba2cfed.yaml
+++ b/models/rave/claim/a4d7aeee-cacb-480d-bb13-0571cba2cfed.yaml
@@ -1,0 +1,9 @@
+type: rave/claim
+typeVersion: 2026.03.22.1
+id: a4d7aeee-cacb-480d-bb13-0571cba2cfed
+name: claim-extensions-compile-001
+version: 1
+tags: {}
+globalArguments:
+  claimId: claim-extensions-compile-001
+methods: {}

--- a/models/rave/claim/df0d3515-91cf-44cc-b36b-5269db80f7b5.yaml
+++ b/models/rave/claim/df0d3515-91cf-44cc-b36b-5269db80f7b5.yaml
@@ -1,0 +1,9 @@
+type: rave/claim
+typeVersion: 2026.03.22.1
+id: df0d3515-91cf-44cc-b36b-5269db80f7b5
+name: claim-branch-protection-001
+version: 1
+tags: {}
+globalArguments:
+  claimId: claim-branch-protection-001
+methods: {}

--- a/rave/claims/claim-branch-protection-001.yaml
+++ b/rave/claims/claim-branch-protection-001.yaml
@@ -1,23 +1,23 @@
-claim_id: "claim-branch-protection-001"
-statement: "The main branch requires a pull request before any commit can be merged"
+claim_id: claim-branch-protection-001
+statement: The main branch requires a pull request before any commit can be merged
 owner:
-  name: "mellens"
-  contact: "mesgme/rave-swamp"
-status: "active"
-category: "change_risk"
+  name: mellens
+  contact: mesgme/rave-swamp
+status: active
+category: change_risk
 scope:
-  type: "pipeline"
-  target: "mesgme/rave-swamp/main"
+  type: pipeline
+  target: mesgme/rave-swamp/main
 assumptions:
-  - "The repository is hosted on GitHub"
-  - "The GitHub branch protection API accurately reflects enforced policy"
-  - "Admin enforcement is enabled so owners cannot bypass protection"
+  - The repository is hosted on GitHub
+  - The GitHub branch protection API accurately reflects enforced policy
+  - Admin enforcement is enabled so owners cannot bypass protection
 falsification_signals:
-  - "Branch protection is disabled or removed from main"
-  - "required_pull_request_reviews is null or missing from protection settings"
-  - "A commit appears on main that is not associated with a merged pull request"
+  - Branch protection is disabled or removed from main
+  - required_pull_request_reviews is null or missing from protection settings
+  - A commit appears on main that is not associated with a merged pull request
 decay_lambda: 0.02
-annotations: []
-
-# confidence_score and last_validated stored in swamp data (confidence-claim-branch-protection-001)
-# Seed values: confidence_score=1.0, last_validated=2026-03-20T00:00:00Z
+annotations:
+  - text: Validated during initial setup. Branch protection confirmed active.
+    author: mellens
+    created_at: 2026-03-22T08:43:10.675Z


### PR DESCRIPTION
## Summary
- Adds `extensions/models/rave_claim.ts` — `rave/claim` model with 6 methods: `create`, `get`, `activate`, `retire`, `contradict`, `annotate`. Reads/writes claim YAML files directly via `context.repoDir`.
- Creates 5 `rave/claim` instances — one per existing claim
- Adds `USAGE.md` — full CRUD reference for claims, evidence, confidence, and falsifiers

## Test plan
- [ ] `swamp model method run claim-branch-protection-001 get` — returns status=active ✓
- [ ] `swamp model method run claim-branch-protection-001 annotate` — annotation written to YAML ✓
- [ ] `swamp model method run claim-test-xxx create` — new claim YAML created ✓ (test instance cleaned up)
- [ ] `swamp model delete <name> --force` required when data exists ✓

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)