### PR TITLE
Wire up remaining evidence instances and expand gather-all-evidence

### DIFF
--- a/models/rave/ci-evidence/34958b81-c77f-46e9-9fd8-3fc2232487b7.yaml
+++ b/models/rave/ci-evidence/34958b81-c77f-46e9-9fd8-3fc2232487b7.yaml
@@ -1,0 +1,12 @@
+type: rave/ci-evidence
+typeVersion: 2026.03.21.1
+id: 34958b81-c77f-46e9-9fd8-3fc2232487b7
+name: evidence-typescript-compile-001
+version: 1
+tags: {}
+globalArguments:
+  evidenceId: evidence-typescript-compile-001
+  repo: mesgme/rave-swamp
+  workflowName: validate.yml
+  branch: main
+methods: {}

--- a/models/rave/ci-evidence/52b47d41-2a67-47b4-9bb4-3e78c5a56500.yaml
+++ b/models/rave/ci-evidence/52b47d41-2a67-47b4-9bb4-3e78c5a56500.yaml
@@ -1,0 +1,12 @@
+type: rave/ci-evidence
+typeVersion: 2026.03.21.1
+id: 52b47d41-2a67-47b4-9bb4-3e78c5a56500
+name: evidence-swamp-model-validate-001
+version: 1
+tags: {}
+globalArguments:
+  evidenceId: evidence-swamp-model-validate-001
+  repo: mesgme/rave-swamp
+  workflowName: validate.yml
+  branch: main
+methods: {}

--- a/models/rave/ci-evidence/69af0d0e-dfe0-466f-a26d-bf334d4948d3.yaml
+++ b/models/rave/ci-evidence/69af0d0e-dfe0-466f-a26d-bf334d4948d3.yaml
@@ -1,0 +1,12 @@
+type: rave/ci-evidence
+typeVersion: 2026.03.21.1
+id: 69af0d0e-dfe0-466f-a26d-bf334d4948d3
+name: evidence-swamp-workflow-validate-001
+version: 1
+tags: {}
+globalArguments:
+  evidenceId: evidence-swamp-workflow-validate-001
+  repo: mesgme/rave-swamp
+  workflowName: validate.yml
+  branch: main
+methods: {}

--- a/rave/claims/claim-ci-green-on-main-001.yaml
+++ b/rave/claims/claim-ci-green-on-main-001.yaml
@@ -1,22 +1,18 @@
-claim_id: "claim-ci-green-on-main-001"
-statement: "All GitHub Actions workflow runs on the main branch succeed"
+claim_id: claim-ci-green-on-main-001
+statement: All GitHub Actions workflow runs on the main branch succeed
 owner:
-  name: "mellens"
-  contact: "mesgme/rave-swamp"
-status: "draft"
-category: "reliability"
+  name: mellens
+  contact: mesgme/rave-swamp
+status: active
+category: reliability
 scope:
-  type: "pipeline"
-  target: "mesgme/rave-swamp/main"
+  type: pipeline
+  target: mesgme/rave-swamp/main
 assumptions:
-  - "At least one workflow run has completed on main in the last 7 days"
-  - "GitHub Actions is the sole CI system for this repository"
+  - At least one workflow run has completed on main in the last 7 days
+  - GitHub Actions is the sole CI system for this repository
 falsification_signals:
-  - "Any workflow run on main has conclusion 'failure' or 'timed_out'"
-  - "No workflow runs have occurred on main in the last 7 days"
+  - Any workflow run on main has conclusion 'failure' or 'timed_out'
+  - No workflow runs have occurred on main in the last 7 days
 decay_lambda: 0.05
 annotations: []
-
-# status=draft until a CI workflow exists in the repo.
-# Activate once .github/workflows/ contains at least one workflow.
-# Seed values: confidence_score=0.0 (draft convention)

--- a/rave/claims/claim-extensions-compile-001.yaml
+++ b/rave/claims/claim-extensions-compile-001.yaml
@@ -1,22 +1,19 @@
-claim_id: "claim-extensions-compile-001"
-statement: "All extension model TypeScript files in extensions/models/ compile without errors"
+claim_id: claim-extensions-compile-001
+statement: All extension model TypeScript files in extensions/models/ compile without errors
 owner:
-  name: "mellens"
-  contact: "mesgme/rave-swamp"
-status: "draft"
-category: "reliability"
+  name: mellens
+  contact: mesgme/rave-swamp
+status: active
+category: reliability
 scope:
-  type: "component"
-  target: "mesgme/rave-swamp/extensions"
+  type: component
+  target: mesgme/rave-swamp/extensions
 assumptions:
-  - "Node.js and TypeScript are available in the CI environment"
-  - "All npm:* import specifiers in extension models pin explicit versions"
-  - "extensions/models/ contains at least one .ts file"
+  - Node.js and TypeScript are available in the CI environment
+  - All npm:* import specifiers in extension models pin explicit versions
+  - extensions/models/ contains at least one .ts file
 falsification_signals:
-  - "tsc --noEmit exits with a non-zero exit code"
-  - "Any extension model file produces a TypeScript type error"
+  - tsc --noEmit exits with a non-zero exit code
+  - Any extension model file produces a TypeScript type error
 decay_lambda: 0.05
 annotations: []
-
-# status=draft until the first extension model is committed.
-# Activate once extensions/models/ is non-empty and compiles cleanly.

--- a/rave/claims/claim-swamp-models-valid-001.yaml
+++ b/rave/claims/claim-swamp-models-valid-001.yaml
@@ -1,23 +1,20 @@
-claim_id: "claim-swamp-models-valid-001"
-statement: "All swamp extension models in extensions/models/ pass schema and argument validation"
+claim_id: claim-swamp-models-valid-001
+statement: All swamp extension models in extensions/models/ pass schema and argument validation
 owner:
-  name: "mellens"
-  contact: "mesgme/rave-swamp"
-status: "draft"
-category: "reliability"
+  name: mellens
+  contact: mesgme/rave-swamp
+status: active
+category: reliability
 scope:
-  type: "component"
-  target: "mesgme/rave-swamp/extensions"
+  type: component
+  target: mesgme/rave-swamp/extensions
 assumptions:
-  - "The swamp CLI is available in the CI environment"
-  - "All extension model TypeScript files are syntactically valid and can be loaded"
-  - "extensions/models/ contains at least one model file"
+  - The swamp CLI is available in the CI environment
+  - All extension model TypeScript files are syntactically valid and can be loaded
+  - extensions/models/ contains at least one model file
 falsification_signals:
   - "swamp model validate --json returns passed: false for any model"
-  - "Any model fails definition schema validation"
-  - "Any model method arguments schema is invalid"
+  - Any model fails definition schema validation
+  - Any model method arguments schema is invalid
 decay_lambda: 0.05
 annotations: []
-
-# status=draft until the first extension model is committed.
-# Activate once extensions/models/ is non-empty and validated.

--- a/rave/claims/claim-swamp-workflows-valid-001.yaml
+++ b/rave/claims/claim-swamp-workflows-valid-001.yaml
@@ -1,22 +1,19 @@
-claim_id: "claim-swamp-workflows-valid-001"
-statement: "All swamp workflow YAML files in workflows/ pass schema validation"
+claim_id: claim-swamp-workflows-valid-001
+statement: All swamp workflow YAML files in workflows/ pass schema validation
 owner:
-  name: "mellens"
-  contact: "mesgme/rave-swamp"
-status: "draft"
-category: "reliability"
+  name: mellens
+  contact: mesgme/rave-swamp
+status: active
+category: reliability
 scope:
-  type: "component"
-  target: "mesgme/rave-swamp/workflows"
+  type: component
+  target: mesgme/rave-swamp/workflows
 assumptions:
-  - "The swamp CLI is available in the CI environment"
-  - "workflows/ contains at least one workflow file"
+  - The swamp CLI is available in the CI environment
+  - workflows/ contains at least one workflow file
 falsification_signals:
   - "swamp workflow validate --json returns passed: false for any workflow"
-  - "Any workflow fails schema validation"
-  - "Any workflow references a model or step that does not exist"
+  - Any workflow fails schema validation
+  - Any workflow references a model or step that does not exist
 decay_lambda: 0.05
 annotations: []
-
-# status=draft until the first workflow is committed.
-# Activate once workflows/ is non-empty and validated.

--- a/workflows/workflow-7ffc2c4d-9b41-481f-8e94-4aac697e70e3.yaml
+++ b/workflows/workflow-7ffc2c4d-9b41-481f-8e94-4aac697e70e3.yaml
@@ -4,13 +4,83 @@ description: Gather all rave-swamp evidence in parallel — one job per evidence
 tags: {}
 jobs:
   - name: ci-test-results
-    description: Gather CI test results evidence
+    description: Gather CI test results evidence (validate.yml run)
     steps:
       - name: fetch
         description: Fetch latest validate.yml run result
         task:
           type: model_method
           modelIdOrName: evidence-ci-test-results-001
+          methodName: gather
+          inputs:
+            githubToken: ${{ vault.get(rave-credentials, GITHUB_TOKEN) }}
+        allowFailure: true
+    dependsOn: []
+    weight: 0
+  - name: swamp-model-validate
+    description: Gather swamp model validation evidence (validate.yml run)
+    steps:
+      - name: fetch
+        description: Fetch latest validate.yml run result for model validation
+        task:
+          type: model_method
+          modelIdOrName: evidence-swamp-model-validate-001
+          methodName: gather
+          inputs:
+            githubToken: ${{ vault.get(rave-credentials, GITHUB_TOKEN) }}
+        allowFailure: true
+    dependsOn: []
+    weight: 0
+  - name: swamp-workflow-validate
+    description: Gather swamp workflow validation evidence (validate.yml run)
+    steps:
+      - name: fetch
+        description: Fetch latest validate.yml run result for workflow validation
+        task:
+          type: model_method
+          modelIdOrName: evidence-swamp-workflow-validate-001
+          methodName: gather
+          inputs:
+            githubToken: ${{ vault.get(rave-credentials, GITHUB_TOKEN) }}
+        allowFailure: true
+    dependsOn: []
+    weight: 0
+  - name: typescript-compile
+    description: Gather TypeScript compile check evidence (validate.yml run)
+    steps:
+      - name: fetch
+        description: Fetch latest validate.yml run result for TS compile check
+        task:
+          type: model_method
+          modelIdOrName: evidence-typescript-compile-001
+          methodName: gather
+          inputs:
+            githubToken: ${{ vault.get(rave-credentials, GITHUB_TOKEN) }}
+        allowFailure: true
+    dependsOn: []
+    weight: 0
+  - name: branch-protection
+    description: Gather GitHub branch protection policy evidence
+    steps:
+      - name: fetch
+        description: Query GitHub branch protection API
+        task:
+          type: model_method
+          modelIdOrName: evidence-github-branch-protection-001
+          methodName: gather
+          inputs:
+            githubToken: ${{ vault.get(rave-credentials, GITHUB_TOKEN) }}
+        allowFailure: true
+    dependsOn: []
+    weight: 0
+  - name: actions-runs
+    description: Gather GitHub Actions run history evidence
+    steps:
+      - name: fetch
+        description: Query GitHub Actions runs API
+        task:
+          type: model_method
+          modelIdOrName: evidence-github-actions-runs-001
           methodName: gather
           inputs:
             githubToken: ${{ vault.get(rave-credentials, GITHUB_TOKEN) }}


### PR DESCRIPTION
## Summary
- Adds 3 missing `rave/ci-evidence` instances (all targeting `validate.yml`): `evidence-swamp-model-validate-001`, `evidence-swamp-workflow-validate-001`, `evidence-typescript-compile-001`
- Expands `gather-all-evidence` from 1 to 6 parallel jobs (all with `allowFailure: true`)
- Activates 4 draft claims now that `validate.yml` CI is live: `claim-ci-green-on-main-001`, `claim-swamp-models-valid-001`, claim-swamp-workflows-valid-001`, `claim-extensions-compile-001`

## Test plan
- [ ] `swamp workflow validate gather-all-evidence --json` → passed ✓
- [ ] All 5 claims now have `status: active`
- [ ] After merge: `swamp workflow run gather-all-evidence` → all 6 jobs complete

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)