### PR TITLE
Fix dashboard data fetch and add sweep keybinding

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -325,6 +325,7 @@ deno task dashboard
 ```
 
 - **↑/↓** — navigate the scope tree
+- **s** — run full sweep (gather evidence → compute confidence → refresh)
 - **r** — refresh confidence data from swamp
 - **q** — quit
 

--- a/bin/lib/confidence.test.ts
+++ b/bin/lib/confidence.test.ts
@@ -3,7 +3,7 @@ import { parseConfidenceResponse } from "./confidence.ts";
 
 Deno.test("parseConfidenceResponse extracts confidence data from swamp JSON", () => {
   const json = JSON.stringify({
-    attributes: {
+    content: {
       claimId: "claim-ci-green-on-main-001",
       confidenceScore: 0.72,
       previousScore: 0.8,
@@ -34,7 +34,7 @@ Deno.test("parseConfidenceResponse returns null for malformed JSON", () => {
 
 Deno.test("parseConfidenceResponse handles null previousScore", () => {
   const json = JSON.stringify({
-    attributes: {
+    content: {
       claimId: "claim-test-001",
       confidenceScore: 0.85,
       previousScore: null,
@@ -50,4 +50,24 @@ Deno.test("parseConfidenceResponse handles null previousScore", () => {
   const data = parseConfidenceResponse(json);
   assertEquals(data?.previousScore, null);
   assertEquals(data?.statusTransition, null);
+});
+
+Deno.test("parseConfidenceResponse falls back to attributes key", () => {
+  const json = JSON.stringify({
+    attributes: {
+      claimId: "claim-legacy-001",
+      confidenceScore: 0.6,
+      previousScore: null,
+      computedAt: "2026-03-30T10:00:00Z",
+      lastValidated: "2026-03-28T10:00:00Z",
+      fAvg: 1.0,
+      qAvg: 1.0,
+      decayFactor: 1.0,
+      statusTransition: null,
+      evidenceSnapshots: [],
+    },
+  });
+  const data = parseConfidenceResponse(json);
+  assertEquals(data?.claimId, "claim-legacy-001");
+  assertEquals(data?.confidenceScore, 0.6);
 });

--- a/bin/lib/confidence.ts
+++ b/bin/lib/confidence.ts
@@ -5,7 +5,7 @@ export function parseConfidenceResponse(raw: string): ConfidenceData | null {
   if (!raw || raw.trim() === "") return null;
   try {
     const parsed = JSON.parse(raw);
-    const attrs = parsed?.attributes;
+    const attrs = parsed?.content ?? parsed?.attributes;
     if (!attrs || typeof attrs.confidenceScore !== "number") return null;
     return {
       claimId: attrs.claimId,
@@ -28,7 +28,7 @@ async function fetchOne(claimId: string): Promise<ConfidenceData | null> {
   const modelName = `confidence-${claimId}`;
   try {
     const cmd = new Deno.Command("swamp", {
-      args: ["data", "get", modelName, "confidence", "--json"],
+      args: ["data", "get", modelName, "current", "--json"],
       stdout: "piped",
       stderr: "piped",
     });

--- a/bin/lib/render.ts
+++ b/bin/lib/render.ts
@@ -198,7 +198,11 @@ function renderReadiness(
 
 // --- Full dashboard ---
 
-export function renderDashboard(state: DashboardState): string {
+export function renderStatusLine(message: string): string {
+  return `  ${YELLOW}${BOLD}⟳ ${message}${RESET}`;
+}
+
+export function renderDashboard(state: DashboardState, statusMessage?: string): string {
   const selectedScope = state.flatScopes[state.selectedScopeIndex];
   const filteredClaims = claimsForScope(state.claims, selectedScope);
   const lines: string[] = [];
@@ -225,9 +229,15 @@ export function renderDashboard(state: DashboardState): string {
   lines.push(`  ${renderReadiness(filteredClaims, state.confidence, state.threshold)}`);
   lines.push("");
 
+  // Status message (shown during sweep)
+  if (statusMessage) {
+    lines.push(renderStatusLine(statusMessage));
+    lines.push("");
+  }
+
   // Footer
   lines.push(
-    `  ${DIM}[↑/↓] Navigate scopes  [r] Refresh  [q] Quit${RESET}`,
+    `  ${DIM}[↑/↓] Navigate scopes  [s] Sweep  [r] Refresh  [q] Quit${RESET}`,
   );
   lines.push("");
 

--- a/bin/rave-dashboard.ts
+++ b/bin/rave-dashboard.ts
@@ -4,6 +4,20 @@ import { fetchAllConfidence } from "./lib/confidence.ts";
 import { renderDashboard, confidenceLevel } from "./lib/render.ts";
 import type { DashboardState } from "./lib/types.ts";
 
+async function runWorkflow(name: string): Promise<boolean> {
+  try {
+    const cmd = new Deno.Command("swamp", {
+      args: ["workflow", "run", name, "--json"],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const output = await cmd.output();
+    return output.success;
+  } catch {
+    return false;
+  }
+}
+
 const CLEAR = "\x1b[2J\x1b[H";
 const SHOW_CURSOR = "\x1b[?25h";
 const HIDE_CURSOR = "\x1b[?25l";
@@ -49,6 +63,11 @@ function outputJson(state: DashboardState) {
 
 function draw(state: DashboardState) {
   const output = renderDashboard(state);
+  Deno.stdout.writeSync(new TextEncoder().encode(CLEAR + HIDE_CURSOR + output));
+}
+
+function drawWithStatus(state: DashboardState, message: string) {
+  const output = renderDashboard(state, message);
   Deno.stdout.writeSync(new TextEncoder().encode(CLEAR + HIDE_CURSOR + output));
 }
 
@@ -101,6 +120,17 @@ async function main() {
         );
       } else if (input === "r") {
         // Refresh confidence data
+        state.confidence = await fetchAllConfidence(
+          state.claims.map((c) => c.claim_id),
+        );
+      } else if (input === "s") {
+        // Run full sweep: gather evidence → compute confidence → refresh
+        drawWithStatus(state, "Running sweep: gathering evidence...");
+        const evidenceOk = await runWorkflow("gather-all-evidence");
+        if (evidenceOk) {
+          drawWithStatus(state, "Running sweep: computing confidence...");
+          await runWorkflow("confidence-decay-sweep");
+        }
         state.confidence = await fetchAllConfidence(
           state.claims.map((c) => c.claim_id),
         );


### PR DESCRIPTION
## Summary

- Fix confidence data not showing: use `content` key (not `attributes`) and data name `current` (not `confidence`) to match actual swamp response shape
- Add `[s]` keybinding to run a full sweep from the TUI (gather-all-evidence → confidence-decay-sweep → refresh)
- Status line shows progress during sweep
- Update USAGE.md with new keybinding

## Test plan

- [x] 24 unit tests pass
- [x] Lint and type check clean
- [x] `deno task dashboard` shows confidence scores after sweep
- [x] `[s]` key triggers evidence gathering + confidence computation
- [x] Scores update in the table after sweep completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)