### PR TITLE
Add governance and ops claims — PR reviews, commit provenance, stale issues

### DIFF
--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -1,0 +1,86 @@
+name: governance-check
+
+on:
+  schedule:
+    - cron: '0 6 * * *'   # 06:00 UTC nightly
+  workflow_dispatch:
+
+jobs:
+  pr-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check merged PRs have at least one approving review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SINCE=$(date -d '30 days ago' --utc +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+            || date -v-30d -u +%Y-%m-%dT%H:%M:%SZ)
+          FAILURES=0
+          for PR in $(gh api "repos/mesgme/rave-swamp/pulls?state=closed&base=main&per_page=50" \
+              --jq '.[] | select(.merged_at != null and .merged_at > "'"$SINCE"'") | .number'); do
+            USER=$(gh api "repos/mesgme/rave-swamp/pulls/$PR" --jq '.user.login')
+            case "$USER" in renovate*|dependabot*|github-actions*) continue ;; esac
+            APPROVED=$(gh api "repos/mesgme/rave-swamp/pulls/$PR/reviews" \
+              --jq '[.[] | select(.state == "APPROVED")] | length')
+            if [ "$APPROVED" -eq 0 ]; then
+              echo "PR #$PR merged to main without an approving review" >&2
+              FAILURES=$((FAILURES+1))
+            fi
+          done
+          exit $FAILURES
+
+  commits-via-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 200
+
+      - name: Check main commits arrived via merged PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          MERGE_SHAS=$(gh api \
+            "repos/mesgme/rave-swamp/pulls?state=closed&base=main&per_page=100" \
+            --jq '[.[] | select(.merged_at != null) | .merge_commit_sha] | .[]')
+
+          FAILURES=0
+          while read SHA; do
+            PARENT_COUNT=$(git cat-file -p "$SHA" | grep -c '^parent ' || echo 0)
+            if [ "$PARENT_COUNT" -eq 0 ]; then
+              continue
+            fi
+            if ! echo "$MERGE_SHAS" | grep -qx "$SHA"; then
+              echo "Commit $SHA on main is not a known PR merge commit" >&2
+              FAILURES=$((FAILURES+1))
+            fi
+          done < <(git log --format='%H' origin/main -50)
+
+          exit $FAILURES
+
+  stale-untriaged-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for stale untriaged open issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CUTOFF=$(date -d '30 days ago' --utc +%Y-%m-%d 2>/dev/null \
+            || date -v-30d -u +%Y-%m-%d)
+
+          STALE=$(gh issue list \
+            --repo mesgme/rave-swamp \
+            --search "is:open no:label created:<${CUTOFF}" \
+            --json number,title,createdAt \
+            --jq 'length')
+
+          if [ "$STALE" -gt 0 ]; then
+            echo "Found $STALE open issue(s) older than 30 days with no label:" >&2
+            gh issue list \
+              --repo mesgme/rave-swamp \
+              --search "is:open no:label created:<${CUTOFF}" \
+              --json number,title,createdAt \
+              --jq '.[] | "#\(.number) \(.title) (created \(.createdAt))"' >&2
+            exit 1
+          fi
+          echo "No stale untriaged issues found."

--- a/models/@mellens/rave/ci-evidence/5d666c84-3a3d-45be-8148-6ed0df3b921f.yaml
+++ b/models/@mellens/rave/ci-evidence/5d666c84-3a3d-45be-8148-6ed0df3b921f.yaml
@@ -1,0 +1,12 @@
+type: '@mellens/rave/ci-evidence'
+typeVersion: 2026.03.21.1
+id: 5d666c84-3a3d-45be-8148-6ed0df3b921f
+name: evidence-main-commits-via-pr-001
+version: 1
+tags: {}
+globalArguments:
+  evidenceId: evidence-main-commits-via-pr-001
+  repo: mesgme/rave-swamp
+  workflowName: governance-check.yml
+  branch: main
+methods: {}

--- a/models/@mellens/rave/ci-evidence/d756d759-379f-425d-869a-af95fb85cdb7.yaml
+++ b/models/@mellens/rave/ci-evidence/d756d759-379f-425d-869a-af95fb85cdb7.yaml
@@ -1,0 +1,12 @@
+type: '@mellens/rave/ci-evidence'
+typeVersion: 2026.03.21.1
+id: d756d759-379f-425d-869a-af95fb85cdb7
+name: evidence-merged-prs-reviewed-001
+version: 1
+tags: {}
+globalArguments:
+  evidenceId: evidence-merged-prs-reviewed-001
+  repo: mesgme/rave-swamp
+  workflowName: governance-check.yml
+  branch: main
+methods: {}

--- a/models/@mellens/rave/ci-evidence/ebeb91f5-6937-4eb5-9574-b48e5e5b5782.yaml
+++ b/models/@mellens/rave/ci-evidence/ebeb91f5-6937-4eb5-9574-b48e5e5b5782.yaml
@@ -1,0 +1,12 @@
+type: '@mellens/rave/ci-evidence'
+typeVersion: 2026.03.21.1
+id: ebeb91f5-6937-4eb5-9574-b48e5e5b5782
+name: evidence-no-stale-untriaged-issues-001
+version: 1
+tags: {}
+globalArguments:
+  evidenceId: evidence-no-stale-untriaged-issues-001
+  repo: mesgme/rave-swamp
+  workflowName: governance-check.yml
+  branch: main
+methods: {}

--- a/models/@mellens/rave/confidence-engine/5fa21e35-e8c6-4298-ae30-24948fbfc788.yaml
+++ b/models/@mellens/rave/confidence-engine/5fa21e35-e8c6-4298-ae30-24948fbfc788.yaml
@@ -1,0 +1,11 @@
+type: '@mellens/rave/confidence-engine'
+typeVersion: 2026.03.21.1
+id: 5fa21e35-e8c6-4298-ae30-24948fbfc788
+name: confidence-claim-no-stale-untriaged-issues-001
+version: 1
+tags: {}
+globalArguments:
+  claimId: claim-no-stale-untriaged-issues-001
+  decayLambda: 0.05
+  confidenceFloor: 0.01
+methods: {}

--- a/models/@mellens/rave/confidence-engine/6805b551-af86-4360-b75a-1260a3a3818f.yaml
+++ b/models/@mellens/rave/confidence-engine/6805b551-af86-4360-b75a-1260a3a3818f.yaml
@@ -1,0 +1,11 @@
+type: '@mellens/rave/confidence-engine'
+typeVersion: 2026.03.21.1
+id: 6805b551-af86-4360-b75a-1260a3a3818f
+name: confidence-claim-main-commits-via-pr-001
+version: 1
+tags: {}
+globalArguments:
+  claimId: claim-main-commits-via-pr-001
+  decayLambda: 0.05
+  confidenceFloor: 0.01
+methods: {}

--- a/models/@mellens/rave/confidence-engine/c3170046-48c0-467e-b8a1-4625ab0305d1.yaml
+++ b/models/@mellens/rave/confidence-engine/c3170046-48c0-467e-b8a1-4625ab0305d1.yaml
@@ -1,0 +1,11 @@
+type: '@mellens/rave/confidence-engine'
+typeVersion: 2026.03.21.1
+id: c3170046-48c0-467e-b8a1-4625ab0305d1
+name: confidence-claim-merged-prs-reviewed-001
+version: 1
+tags: {}
+globalArguments:
+  claimId: claim-merged-prs-reviewed-001
+  decayLambda: 0.05
+  confidenceFloor: 0.01
+methods: {}

--- a/models/@mellens/rave/falsifier-engine/02d799c4-3129-4605-8675-1d94105f978c.yaml
+++ b/models/@mellens/rave/falsifier-engine/02d799c4-3129-4605-8675-1d94105f978c.yaml
@@ -1,0 +1,11 @@
+type: '@mellens/rave/falsifier-engine'
+typeVersion: 2026.03.21.1
+id: 02d799c4-3129-4605-8675-1d94105f978c
+name: falsifier-direct-push-detected-001
+version: 1
+tags: {}
+globalArguments:
+  falsifierId: falsifier-direct-push-detected-001
+  conditionType: boolean
+  condition: '{"field":"$.conclusion","expected":"success"}'
+methods: {}

--- a/models/@mellens/rave/falsifier-engine/9c66165c-c07a-4083-ab97-6b1897256480.yaml
+++ b/models/@mellens/rave/falsifier-engine/9c66165c-c07a-4083-ab97-6b1897256480.yaml
@@ -1,0 +1,11 @@
+type: '@mellens/rave/falsifier-engine'
+typeVersion: 2026.03.21.1
+id: 9c66165c-c07a-4083-ab97-6b1897256480
+name: falsifier-pr-review-missing-001
+version: 1
+tags: {}
+globalArguments:
+  falsifierId: falsifier-pr-review-missing-001
+  conditionType: boolean
+  condition: '{"field":"$.conclusion","expected":"success"}'
+methods: {}

--- a/models/@mellens/rave/falsifier-engine/bf3a5ab1-e708-498c-88f5-9284573ac5df.yaml
+++ b/models/@mellens/rave/falsifier-engine/bf3a5ab1-e708-498c-88f5-9284573ac5df.yaml
@@ -1,0 +1,11 @@
+type: '@mellens/rave/falsifier-engine'
+typeVersion: 2026.03.21.1
+id: bf3a5ab1-e708-498c-88f5-9284573ac5df
+name: falsifier-stale-untriaged-issue-001
+version: 1
+tags: {}
+globalArguments:
+  falsifierId: falsifier-stale-untriaged-issue-001
+  conditionType: boolean
+  condition: '{"field":"$.conclusion","expected":"success"}'
+methods: {}

--- a/rave/claims/claim-main-commits-via-pr-001.yaml
+++ b/rave/claims/claim-main-commits-via-pr-001.yaml
@@ -1,0 +1,19 @@
+claim_id: claim-main-commits-via-pr-001
+statement: Every commit on main arrived via a merged pull request — no direct pushes
+owner:
+  name: mellens
+  contact: mesgme/rave-swamp
+status: active
+category: change_risk
+scope:
+  type: pipeline
+  target: mesgme/rave-swamp/main
+assumptions:
+  - GitHub API merge_commit_sha fields are reliable identifiers for PR-backed commits
+  - Root commits (zero parents) are whitelisted as pre-policy bootstrap commits
+  - The check covers the last 50 commits on main against the last 100 merged PRs
+falsification_signals:
+  - A commit SHA on main does not appear as the merge_commit_sha of any known merged PR
+  - A direct push bypasses branch protection via admin override
+decay_lambda: 0.02
+annotations: []

--- a/rave/claims/claim-merged-prs-reviewed-001.yaml
+++ b/rave/claims/claim-merged-prs-reviewed-001.yaml
@@ -1,0 +1,19 @@
+claim_id: claim-merged-prs-reviewed-001
+statement: Every PR merged to main in the last 30 days had at least one approving review before merge
+owner:
+  name: mellens
+  contact: mesgme/rave-swamp
+status: active
+category: change_risk
+scope:
+  type: pipeline
+  target: mesgme/rave-swamp/main
+assumptions:
+  - The GitHub API pulls endpoint is authoritative for review state
+  - PRs merged by bots (renovate, dependabot, github-actions) are excluded
+  - A single APPROVED review from any collaborator satisfies the claim
+falsification_signals:
+  - Any merged PR in the last 30 days has zero APPROVED reviews
+  - A merge commit appears on main from a PR with only COMMENTED or CHANGES_REQUESTED reviews
+decay_lambda: 0.03
+annotations: []

--- a/rave/claims/claim-no-stale-untriaged-issues-001.yaml
+++ b/rave/claims/claim-no-stale-untriaged-issues-001.yaml
@@ -1,0 +1,19 @@
+claim_id: claim-no-stale-untriaged-issues-001
+statement: No open issue is older than 30 days without at least one label
+owner:
+  name: mellens
+  contact: mesgme/rave-swamp
+status: active
+category: process
+scope:
+  type: pipeline
+  target: mesgme/rave-swamp/main
+assumptions:
+  - All issues are filed in mesgme/rave-swamp
+  - The presence of any label is sufficient evidence of triage
+  - Issues created by bots are subject to the same 30-day rule
+falsification_signals:
+  - Any open issue older than 30 days has no labels attached
+  - A burst of unlabelled issues remains unreviewed after the 30-day window
+decay_lambda: 0.10
+annotations: []

--- a/rave/evidence/evidence-main-commits-via-pr-001.yaml
+++ b/rave/evidence/evidence-main-commits-via-pr-001.yaml
@@ -1,0 +1,22 @@
+evidence_id: "evidence-main-commits-via-pr-001"
+type: "ci_log"
+description: "Nightly governance check verifying all recent main commits are PR merge commits"
+reference:
+  uri: "https://api.github.com/repos/mesgme/rave-swamp/actions/workflows/governance-check.yml/runs?branch=main&per_page=1"
+  format: "application/json"
+  authentication:
+    method: "bearer_token"
+    hint: "GITHUB_TOKEN"
+claim_ids:
+  - "claim-main-commits-via-pr-001"
+freshness_window: "P2D"
+quality_score: 0.80
+methodology:
+  description: "Nightly workflow cross-references main commit SHAs against merged PR merge_commit_sha values via GitHub API; exits non-zero on any unmatched SHA"
+  tooling: "github-actions"
+  frequency: "P1D"
+  coverage: "Last 50 commits on main, cross-referenced against last 100 merged PRs"
+metadata:
+  source_system: "github-actions"
+  repo: "mesgme/rave-swamp"
+  workflow: "governance-check.yml"

--- a/rave/evidence/evidence-merged-prs-reviewed-001.yaml
+++ b/rave/evidence/evidence-merged-prs-reviewed-001.yaml
@@ -1,0 +1,22 @@
+evidence_id: "evidence-merged-prs-reviewed-001"
+type: "ci_log"
+description: "Nightly governance check verifying all recent merged PRs had at least one approving review"
+reference:
+  uri: "https://api.github.com/repos/mesgme/rave-swamp/actions/workflows/governance-check.yml/runs?branch=main&per_page=1"
+  format: "application/json"
+  authentication:
+    method: "bearer_token"
+    hint: "GITHUB_TOKEN"
+claim_ids:
+  - "claim-merged-prs-reviewed-001"
+freshness_window: "P2D"
+quality_score: 0.85
+methodology:
+  description: "Nightly GitHub Actions workflow queries merged PRs via GitHub API and exits non-zero if any merged PR lacks an APPROVED review"
+  tooling: "github-actions"
+  frequency: "P1D"
+  coverage: "All non-bot PRs merged to main in the last 30 days"
+metadata:
+  source_system: "github-actions"
+  repo: "mesgme/rave-swamp"
+  workflow: "governance-check.yml"

--- a/rave/evidence/evidence-no-stale-untriaged-issues-001.yaml
+++ b/rave/evidence/evidence-no-stale-untriaged-issues-001.yaml
@@ -1,0 +1,22 @@
+evidence_id: "evidence-no-stale-untriaged-issues-001"
+type: "ci_log"
+description: "Nightly governance check verifying no open issue in mesgme/rave-swamp is older than 30 days without a label"
+reference:
+  uri: "https://api.github.com/repos/mesgme/rave-swamp/actions/workflows/governance-check.yml/runs?branch=main&per_page=1"
+  format: "application/json"
+  authentication:
+    method: "bearer_token"
+    hint: "GITHUB_TOKEN"
+claim_ids:
+  - "claim-no-stale-untriaged-issues-001"
+freshness_window: "P2D"
+quality_score: 0.85
+methodology:
+  description: "Nightly workflow queries GitHub Issues API for open issues with no labels created >30 days ago; exits non-zero if any exist"
+  tooling: "github-actions"
+  frequency: "P1D"
+  coverage: "All open issues in mesgme/rave-swamp"
+metadata:
+  source_system: "github-actions"
+  repo: "mesgme/rave-swamp"
+  workflow: "governance-check.yml"

--- a/rave/falsifiers/falsifier-direct-push-detected-001.yaml
+++ b/rave/falsifiers/falsifier-direct-push-detected-001.yaml
@@ -1,0 +1,14 @@
+falsifier_id: "falsifier-direct-push-detected-001"
+name: "Direct Push to Main Detected"
+description: "Detects when the nightly commit provenance check exits non-zero, indicating at least one commit on main is not associated with a merged PR."
+condition:
+  type: "boolean"
+  parameters:
+    field: "$.conclusion"
+    expected: "success"
+evidence_ids:
+  - "evidence-main-commits-via-pr-001"
+claim_ids:
+  - "claim-main-commits-via-pr-001"
+metadata:
+  repo: "mesgme/rave-swamp"

--- a/rave/falsifiers/falsifier-pr-review-missing-001.yaml
+++ b/rave/falsifiers/falsifier-pr-review-missing-001.yaml
@@ -1,0 +1,14 @@
+falsifier_id: "falsifier-pr-review-missing-001"
+name: "Merged PR Without Approving Review"
+description: "Detects when the nightly PR review check exits non-zero, indicating at least one PR was merged to main without an APPROVED review."
+condition:
+  type: "boolean"
+  parameters:
+    field: "$.conclusion"
+    expected: "success"
+evidence_ids:
+  - "evidence-merged-prs-reviewed-001"
+claim_ids:
+  - "claim-merged-prs-reviewed-001"
+metadata:
+  repo: "mesgme/rave-swamp"

--- a/rave/falsifiers/falsifier-stale-untriaged-issue-001.yaml
+++ b/rave/falsifiers/falsifier-stale-untriaged-issue-001.yaml
@@ -1,0 +1,14 @@
+falsifier_id: "falsifier-stale-untriaged-issue-001"
+name: "Stale Untriaged Issue Detected"
+description: "Detects when the nightly stale-issue check exits non-zero, indicating at least one open issue is older than 30 days without a label."
+condition:
+  type: "boolean"
+  parameters:
+    field: "$.conclusion"
+    expected: "success"
+evidence_ids:
+  - "evidence-no-stale-untriaged-issues-001"
+claim_ids:
+  - "claim-no-stale-untriaged-issues-001"
+metadata:
+  repo: "mesgme/rave-swamp"

--- a/workflows/workflow-2da6b960-0b08-494b-95b6-6b21ee8f7e25.yaml
+++ b/workflows/workflow-2da6b960-0b08-494b-95b6-6b21ee8f7e25.yaml
@@ -164,3 +164,63 @@ jobs:
                 freshnessWindow: "P1D"
                 value: null
                 rawData: null
+  - name: pr-review-missing
+    description: Evaluate falsifier-pr-review-missing-001 against PR review governance evidence
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: evaluate
+        description: Check if nightly PR review governance check passed
+        allowFailure: true
+        task:
+          type: model_method
+          modelIdOrName: falsifier-pr-review-missing-001
+          methodName: evaluate
+          inputs:
+            evidence:
+              - evidenceId: "evidence-merged-prs-reviewed-001"
+                outcome: ${{ data.latest("evidence-merged-prs-reviewed-001", "latest").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-merged-prs-reviewed-001", "latest").attributes.timestamp }}
+                freshnessWindow: "P2D"
+                value: null
+                rawData: null
+  - name: direct-push-detected
+    description: Evaluate falsifier-direct-push-detected-001 against commit provenance governance evidence
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: evaluate
+        description: Check if nightly commit provenance check passed
+        allowFailure: true
+        task:
+          type: model_method
+          modelIdOrName: falsifier-direct-push-detected-001
+          methodName: evaluate
+          inputs:
+            evidence:
+              - evidenceId: "evidence-main-commits-via-pr-001"
+                outcome: ${{ data.latest("evidence-main-commits-via-pr-001", "latest").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-main-commits-via-pr-001", "latest").attributes.timestamp }}
+                freshnessWindow: "P2D"
+                value: null
+                rawData: null
+  - name: stale-untriaged-issue
+    description: Evaluate falsifier-stale-untriaged-issue-001 against stale issue governance evidence
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: evaluate
+        description: Check if nightly stale issue check passed
+        allowFailure: true
+        task:
+          type: model_method
+          modelIdOrName: falsifier-stale-untriaged-issue-001
+          methodName: evaluate
+          inputs:
+            evidence:
+              - evidenceId: "evidence-no-stale-untriaged-issues-001"
+                outcome: ${{ data.latest("evidence-no-stale-untriaged-issues-001", "latest").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-no-stale-untriaged-issues-001", "latest").attributes.timestamp }}
+                freshnessWindow: "P2D"
+                value: null
+                rawData: null

--- a/workflows/workflow-7ffc2c4d-9b41-481f-8e94-4aac697e70e3.yaml
+++ b/workflows/workflow-7ffc2c4d-9b41-481f-8e94-4aac697e70e3.yaml
@@ -129,4 +129,46 @@ jobs:
         allowFailure: true
     dependsOn: []
     weight: 0
+  - name: merged-prs-reviewed
+    description: Gather PR review governance evidence (governance-check.yml run)
+    steps:
+      - name: fetch
+        description: Fetch latest governance-check.yml run result for PR review check
+        task:
+          type: model_method
+          modelIdOrName: evidence-merged-prs-reviewed-001
+          methodName: gather
+          inputs:
+            githubToken: ${{ vault.get(rave-credentials, GITHUB_TOKEN) }}
+        allowFailure: true
+    dependsOn: []
+    weight: 0
+  - name: main-commits-via-pr
+    description: Gather commit provenance governance evidence (governance-check.yml run)
+    steps:
+      - name: fetch
+        description: Fetch latest governance-check.yml run result for commit provenance check
+        task:
+          type: model_method
+          modelIdOrName: evidence-main-commits-via-pr-001
+          methodName: gather
+          inputs:
+            githubToken: ${{ vault.get(rave-credentials, GITHUB_TOKEN) }}
+        allowFailure: true
+    dependsOn: []
+    weight: 0
+  - name: no-stale-untriaged-issues
+    description: Gather stale issue triage governance evidence (governance-check.yml run)
+    steps:
+      - name: fetch
+        description: Fetch latest governance-check.yml run result for stale issue check
+        task:
+          type: model_method
+          modelIdOrName: evidence-no-stale-untriaged-issues-001
+          methodName: gather
+          inputs:
+            githubToken: ${{ vault.get(rave-credentials, GITHUB_TOKEN) }}
+        allowFailure: true
+    dependsOn: []
+    weight: 0
 version: 1

--- a/workflows/workflow-fd0aacde-a1bc-46d1-bd64-3b1a8c239263.yaml
+++ b/workflows/workflow-fd0aacde-a1bc-46d1-bd64-3b1a8c239263.yaml
@@ -185,3 +185,69 @@ jobs:
                 timestamp: ${{ data.latest("evidence-code-coverage-001", "latest").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.9
+  - name: merged-prs-reviewed
+    description: Recompute confidence for claim-merged-prs-reviewed-001
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: compute
+        description: Apply RAVE decay formula with latest PR review evidence
+        allowFailure: true
+        task:
+          type: model_method
+          modelIdOrName: confidence-claim-merged-prs-reviewed-001
+          methodName: compute
+          inputs:
+            currentScore: ${{ data.latest("confidence-claim-merged-prs-reviewed-001", "current").attributes.confidenceScore }}
+            lastValidated: ${{ data.latest("confidence-claim-merged-prs-reviewed-001", "current").attributes.computedAt }}
+            currentStatus: "active"
+            evidence:
+              - evidenceId: "evidence-merged-prs-reviewed-001"
+                outcome: ${{ data.latest("evidence-merged-prs-reviewed-001", "latest").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-merged-prs-reviewed-001", "latest").attributes.timestamp }}
+                freshnessWindow: "P2D"
+                qualityScore: 0.85
+  - name: main-commits-via-pr
+    description: Recompute confidence for claim-main-commits-via-pr-001
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: compute
+        description: Apply RAVE decay formula with latest commit provenance evidence
+        allowFailure: true
+        task:
+          type: model_method
+          modelIdOrName: confidence-claim-main-commits-via-pr-001
+          methodName: compute
+          inputs:
+            currentScore: ${{ data.latest("confidence-claim-main-commits-via-pr-001", "current").attributes.confidenceScore }}
+            lastValidated: ${{ data.latest("confidence-claim-main-commits-via-pr-001", "current").attributes.computedAt }}
+            currentStatus: "active"
+            evidence:
+              - evidenceId: "evidence-main-commits-via-pr-001"
+                outcome: ${{ data.latest("evidence-main-commits-via-pr-001", "latest").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-main-commits-via-pr-001", "latest").attributes.timestamp }}
+                freshnessWindow: "P2D"
+                qualityScore: 0.80
+  - name: no-stale-untriaged-issues
+    description: Recompute confidence for claim-no-stale-untriaged-issues-001
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: compute
+        description: Apply RAVE decay formula with latest stale issue evidence
+        allowFailure: true
+        task:
+          type: model_method
+          modelIdOrName: confidence-claim-no-stale-untriaged-issues-001
+          methodName: compute
+          inputs:
+            currentScore: ${{ data.latest("confidence-claim-no-stale-untriaged-issues-001", "current").attributes.confidenceScore }}
+            lastValidated: ${{ data.latest("confidence-claim-no-stale-untriaged-issues-001", "current").attributes.computedAt }}
+            currentStatus: "active"
+            evidence:
+              - evidenceId: "evidence-no-stale-untriaged-issues-001"
+                outcome: ${{ data.latest("evidence-no-stale-untriaged-issues-001", "latest").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-no-stale-untriaged-issues-001", "latest").attributes.timestamp }}
+                freshnessWindow: "P2D"
+                qualityScore: 0.85


### PR DESCRIPTION
## Summary

Implements issues #50, #51, #52.

Three new active RAVE claims with full instrumentation (nightly CI enforcement, evidence gathering, confidence decay, falsifier sweep):

| Claim ID | Statement | λ | Category |
|---|---|---|---|
| `claim-merged-prs-reviewed-001` | Every PR merged to main in the last 30 days had at least one approving review | 0.03 | change_risk |
| `claim-main-commits-via-pr-001` | Every commit on main arrived via a merged pull request — no direct pushes | 0.02 | change_risk |
| `claim-no-stale-untriaged-issues-001` | No open issue is older than 30 days without at least one label | 0.10 | process |

## New Workflow (`.github/workflows/governance-check.yml`)

Runs nightly at 06:00 UTC and on `workflow_dispatch`. Three parallel jobs:
- **`pr-reviews`** — queries merged PRs via GitHub API; fails if any non-bot PR has zero APPROVED reviews
- **`commits-via-pr`** — cross-references last 50 main commits against last 100 PR merge SHAs; fails on any unmatched SHA (root commits excepted)
- **`stale-untriaged-issues`** — queries open issues with no labels older than 30 days; fails if any exist

## RAVE Entity Files Added

9 new YAML files in `rave/claims/`, `rave/evidence/`, `rave/falsifiers/`.
All three evidence entities point at `governance-check.yml`, freshness `P2D`.

## Swamp Changes

- 9 new model instances (3 `ci-evidence`, 3 `confidence-engine`, 3 `falsifier-engine`)
- `gather-all-evidence`, `confidence-decay-sweep`, `falsifier-sweep` each gain 3 new parallel jobs

## Test plan

- [ ] `swamp model validate --json` → passed
- [ ] `swamp workflow validate --json` → passed
- [ ] Trigger `governance-check.yml` via `workflow_dispatch` → all 3 jobs pass
- [ ] `swamp workflow run gather-all-evidence` → all 3 new governance jobs succeed (after first governance-check.yml run)
- [ ] `swamp workflow run confidence-decay-sweep` → all 3 new governance jobs succeed
- [ ] `swamp workflow run falsifier-sweep` → all 3 new governance jobs succeed

Closes #50, #51, #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)