### PR TITLE
Fix workflow YAML corruption from merge

### DIFF
--- a/workflows/workflow-2da6b960-0b08-494b-95b6-6b21ee8f7e25.yaml
+++ b/workflows/workflow-2da6b960-0b08-494b-95b6-6b21ee8f7e25.yaml
@@ -166,8 +166,6 @@ jobs:
                 rawData: null
   - name: pr-review-missing
     description: Evaluate falsifier-pr-review-missing-001 against PR review governance evidence
-  - name: secrets-detected
-    description: Evaluate falsifier-secrets-detected-001 against secrets scan CI evidence
     dependsOn: []
     weight: 0
     steps:
@@ -186,8 +184,12 @@ jobs:
                 freshnessWindow: "P2D"
                 value: null
                 rawData: null
-  - name: direct-push-detected
-    description: Evaluate falsifier-direct-push-detected-001 against commit provenance governance evidence
+  - name: secrets-detected
+    description: Evaluate falsifier-secrets-detected-001 against secrets scan CI evidence
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: evaluate
         description: Check if gitleaks scan passed
         allowFailure: true
         task:
@@ -202,8 +204,8 @@ jobs:
                 freshnessWindow: "P1D"
                 value: null
                 rawData: null
-  - name: cve-detected
-    description: Evaluate falsifier-cve-detected-001 against CVE scan CI evidence
+  - name: direct-push-detected
+    description: Evaluate falsifier-direct-push-detected-001 against commit provenance governance evidence
     dependsOn: []
     weight: 0
     steps:
@@ -222,8 +224,12 @@ jobs:
                 freshnessWindow: "P2D"
                 value: null
                 rawData: null
-  - name: stale-untriaged-issue
-    description: Evaluate falsifier-stale-untriaged-issue-001 against stale issue governance evidence
+  - name: cve-detected
+    description: Evaluate falsifier-cve-detected-001 against CVE scan CI evidence
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: evaluate
         description: Check if osv-scanner passed
         allowFailure: true
         task:
@@ -238,8 +244,8 @@ jobs:
                 freshnessWindow: "P1D"
                 value: null
                 rawData: null
-  - name: lock-file-stale
-    description: Evaluate falsifier-lock-file-stale-001 against deno.lock CI evidence
+  - name: stale-untriaged-issue
+    description: Evaluate falsifier-stale-untriaged-issue-001 against stale issue governance evidence
     dependsOn: []
     weight: 0
     steps:
@@ -256,6 +262,14 @@ jobs:
                 outcome: ${{ data.latest("evidence-no-stale-untriaged-issues-001", "latest").attributes.outcome }}
                 timestamp: ${{ data.latest("evidence-no-stale-untriaged-issues-001", "latest").attributes.timestamp }}
                 freshnessWindow: "P2D"
+                value: null
+                rawData: null
+  - name: lock-file-stale
+    description: Evaluate falsifier-lock-file-stale-001 against deno.lock CI evidence
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: evaluate
         description: Check if deno cache --frozen passed
         allowFailure: true
         task:

--- a/workflows/workflow-7ffc2c4d-9b41-481f-8e94-4aac697e70e3.yaml
+++ b/workflows/workflow-7ffc2c4d-9b41-481f-8e94-4aac697e70e3.yaml
@@ -137,6 +137,12 @@ jobs:
         task:
           type: model_method
           modelIdOrName: evidence-merged-prs-reviewed-001
+          methodName: gather
+          inputs:
+            githubToken: ${{ vault.get(rave-credentials, GITHUB_TOKEN) }}
+        allowFailure: true
+    dependsOn: []
+    weight: 0
   - name: no-secrets
     description: Gather secrets scan evidence (validate.yml run)
     steps:
@@ -159,6 +165,12 @@ jobs:
         task:
           type: model_method
           modelIdOrName: evidence-main-commits-via-pr-001
+          methodName: gather
+          inputs:
+            githubToken: ${{ vault.get(rave-credentials, GITHUB_TOKEN) }}
+        allowFailure: true
+    dependsOn: []
+    weight: 0
   - name: no-known-cves
     description: Gather CVE scan evidence (validate.yml run)
     steps:
@@ -181,6 +193,12 @@ jobs:
         task:
           type: model_method
           modelIdOrName: evidence-no-stale-untriaged-issues-001
+          methodName: gather
+          inputs:
+            githubToken: ${{ vault.get(rave-credentials, GITHUB_TOKEN) }}
+        allowFailure: true
+    dependsOn: []
+    weight: 0
   - name: deno-lock-committed
     description: Gather deno.lock verification evidence (validate.yml run)
     steps:

--- a/workflows/workflow-fd0aacde-a1bc-46d1-bd64-3b1a8c239263.yaml
+++ b/workflows/workflow-fd0aacde-a1bc-46d1-bd64-3b1a8c239263.yaml
@@ -187,8 +187,6 @@ jobs:
                 qualityScore: 0.9
   - name: merged-prs-reviewed
     description: Recompute confidence for claim-merged-prs-reviewed-001
-  - name: no-secrets
-    description: Recompute confidence for claim-no-secrets-committed-001
     dependsOn: []
     weight: 0
     steps:
@@ -209,8 +207,12 @@ jobs:
                 timestamp: ${{ data.latest("evidence-merged-prs-reviewed-001", "latest").attributes.timestamp }}
                 freshnessWindow: "P2D"
                 qualityScore: 0.85
-  - name: main-commits-via-pr
-    description: Recompute confidence for claim-main-commits-via-pr-001
+  - name: no-secrets
+    description: Recompute confidence for claim-no-secrets-committed-001
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: compute
         description: Apply RAVE decay formula with latest secrets scan evidence
         allowFailure: true
         task:
@@ -227,8 +229,8 @@ jobs:
                 timestamp: ${{ data.latest("evidence-no-secrets-committed-001", "latest").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.95
-  - name: no-known-cves
-    description: Recompute confidence for claim-no-known-cves-001
+  - name: main-commits-via-pr
+    description: Recompute confidence for claim-main-commits-via-pr-001
     dependsOn: []
     weight: 0
     steps:
@@ -249,8 +251,12 @@ jobs:
                 timestamp: ${{ data.latest("evidence-main-commits-via-pr-001", "latest").attributes.timestamp }}
                 freshnessWindow: "P2D"
                 qualityScore: 0.80
-  - name: no-stale-untriaged-issues
-    description: Recompute confidence for claim-no-stale-untriaged-issues-001
+  - name: no-known-cves
+    description: Recompute confidence for claim-no-known-cves-001
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: compute
         description: Apply RAVE decay formula with latest CVE scan evidence
         allowFailure: true
         task:
@@ -267,8 +273,8 @@ jobs:
                 timestamp: ${{ data.latest("evidence-no-known-cves-001", "latest").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.90
-  - name: deno-lock-committed
-    description: Recompute confidence for claim-deno-lock-committed-001
+  - name: no-stale-untriaged-issues
+    description: Recompute confidence for claim-no-stale-untriaged-issues-001
     dependsOn: []
     weight: 0
     steps:
@@ -289,6 +295,12 @@ jobs:
                 timestamp: ${{ data.latest("evidence-no-stale-untriaged-issues-001", "latest").attributes.timestamp }}
                 freshnessWindow: "P2D"
                 qualityScore: 0.85
+  - name: deno-lock-committed
+    description: Recompute confidence for claim-deno-lock-committed-001
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: compute
         description: Apply RAVE decay formula with latest lock file evidence
         allowFailure: true
         task:


### PR DESCRIPTION
## Summary
- Three workflow files (`gather-all-evidence`, `confidence-decay-sweep`, `falsifier-sweep`) had interleaved/corrupted job structures from the merge of #53 and #54
- Governance jobs were missing `steps`, `dependsOn`, and `weight`, with those fields appearing inside adjacent non-governance jobs
- Reconstructed all three files with each job correctly formed and all steps pointing at the right model

## Verification
- `swamp workflow validate --json` → `totalPassed: 6, totalFailed: 0, passed: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)