### PR TITLE
Fix dashboard crash: quote npm: in claim statement

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -88,3 +88,6 @@ jobs:
 
       - name: Code coverage
         run: deno test --coverage=cov_profile extensions/models/ && (deno coverage cov_profile --detailed || true)
+
+      - name: Dashboard tests
+        run: deno task dashboard:test

--- a/bin/lib/claims.test.ts
+++ b/bin/lib/claims.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "jsr:@std/assert@1";
-import { parseClaimYaml, claimsForScope } from "./claims.ts";
+import { assertEquals, assertGreater } from "jsr:@std/assert@1";
+import { parseClaimYaml, parseClaimFiles, claimsForScope } from "./claims.ts";
 import type { ScopeNode } from "./types.ts";
 
 const SAMPLE_CLAIM = `
@@ -16,6 +16,17 @@ scope:
 decay_lambda: 0.02
 annotations: []
 `;
+
+// Smoke test: parse all real claim files from disk (catches YAML syntax errors like unquoted colons)
+Deno.test("parseClaimFiles loads all rave/claims/*.yaml without error", async () => {
+  const claims = await parseClaimFiles("rave/claims");
+  assertGreater(claims.length, 0);
+  for (const claim of claims) {
+    assertEquals(typeof claim.claim_id, "string");
+    assertEquals(typeof claim.statement, "string");
+    assertEquals(typeof claim.status, "string");
+  }
+});
 
 Deno.test("parseClaimYaml extracts claim fields", () => {
   const claim = parseClaimYaml(SAMPLE_CLAIM);

--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,7 @@
   "specifiers": {
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/yaml@1": "1.0.12",
     "npm:yaml@2": "2.8.3",
     "npm:zod@4": "4.3.6"
   },
@@ -15,6 +16,9 @@
     },
     "@std/internal@1.0.12": {
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
+    },
+    "@std/yaml@1.0.12": {
+      "integrity": "7deabca4545bcedd07c5f69ea53acea71b8b4c67562f224e17b90d75944cb20c"
     }
   },
   "npm": {

--- a/rave/claims/claim-npm-imports-pinned-001.yaml
+++ b/rave/claims/claim-npm-imports-pinned-001.yaml
@@ -1,5 +1,5 @@
 claim_id: claim-npm-imports-pinned-001
-statement: Every npm: import specifier in extensions/models/ includes an explicit @version
+statement: "Every npm: import specifier in extensions/models/ includes an explicit @version"
 owner:
   name: mellens
   contact: mesgme/rave-swamp


### PR DESCRIPTION
## Summary
- `claim-npm-imports-pinned-001.yaml` had an unquoted `npm:` in the `statement` field — the YAML parser treated the colon as a mapping key separator, crashing the dashboard on startup
- Added a smoke test (`parseClaimFiles loads all rave/claims/*.yaml without error`) that parses every real claim file from disk, catching this class of error before merge
- Wired `deno task dashboard:test` into `validate.yml` so it runs on every PR

## Test
```bash
deno task dashboard:test  # 25 passed, 0 failed
deno task dashboard       # opens correctly
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)