### PR TITLE
Default confidence to 0.000 when no data exists

### DIFF
--- a/bin/lib/confidence.test.ts
+++ b/bin/lib/confidence.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "jsr:@std/assert@1";
-import { parseConfidenceResponse } from "./confidence.ts";
+import { parseConfidenceResponse, fetchAllConfidence } from "./confidence.ts";
 
 Deno.test("parseConfidenceResponse extracts confidence data from swamp JSON", () => {
   const json = JSON.stringify({
@@ -50,6 +50,14 @@ Deno.test("parseConfidenceResponse handles null previousScore", () => {
   const data = parseConfidenceResponse(json);
   assertEquals(data?.previousScore, null);
   assertEquals(data?.statusTransition, null);
+});
+
+Deno.test("fetchAllConfidence defaults to score 0 for claims with no data", async () => {
+  // "claim-does-not-exist-001" has no swamp data, so swamp data get returns non-zero exit
+  const map = await fetchAllConfidence(["claim-does-not-exist-001"]);
+  const entry = map.get("claim-does-not-exist-001");
+  assertEquals(entry?.confidenceScore, 0);
+  assertEquals(entry?.previousScore, null);
 });
 
 Deno.test("parseConfidenceResponse falls back to attributes key", () => {

--- a/bin/lib/confidence.ts
+++ b/bin/lib/confidence.ts
@@ -41,7 +41,19 @@ async function fetchOne(claimId: string): Promise<ConfidenceData | null> {
   }
 }
 
-/** Fetch confidence data for all claims in parallel. */
+const ZERO_CONFIDENCE = (claimId: string): ConfidenceData => ({
+  claimId,
+  confidenceScore: 0,
+  previousScore: null,
+  computedAt: "",
+  lastValidated: "",
+  fAvg: 0,
+  qAvg: 0,
+  decayFactor: 0,
+  statusTransition: null,
+});
+
+/** Fetch confidence data for all claims in parallel. Claims with no data default to score 0. */
 export async function fetchAllConfidence(
   claimIds: string[],
 ): Promise<Map<string, ConfidenceData>> {
@@ -50,8 +62,8 @@ export async function fetchAllConfidence(
   );
   const map = new Map<string, ConfidenceData>();
   for (const result of results) {
-    if (result.status === "fulfilled" && result.value.data) {
-      map.set(result.value.id, result.value.data);
+    if (result.status === "fulfilled") {
+      map.set(result.value.id, result.value.data ?? ZERO_CONFIDENCE(result.value.id));
     }
   }
   return map;


### PR DESCRIPTION
## Summary
- Claims with no seeded confidence data now show `● 0.000` (critical, bright red) instead of `N/A`
- Implemented in `fetchAllConfidence` — any claim whose `swamp data get` returns nothing gets a synthetic entry with `confidenceScore: 0`
- All downstream consumers (table, readiness summary, JSON output) see a real number with no special-case handling needed

## Why
A claim that has never been validated has zero confidence by definition. Showing N/A on first run made the dashboard look broken rather than communicating a meaningful state.

## Test
- New test: `fetchAllConfidence defaults to score 0 for claims with no data`
- `deno task dashboard:test` → 26 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)