### PR TITLE
Auto-sweep on startup; show ─ for uncomputed claims

### DIFF
--- a/bin/lib/render.test.ts
+++ b/bin/lib/render.test.ts
@@ -62,7 +62,7 @@ Deno.test("renderScopeTree renders children with connectors", () => {
 
 // --- renderClaimsTable ---
 
-Deno.test("renderClaimsTable shows N/A for missing confidence", () => {
+Deno.test("renderClaimsTable shows ─ for missing confidence", () => {
   const claims: Claim[] = [{
     claim_id: "claim-test-001",
     statement: "test",
@@ -74,7 +74,7 @@ Deno.test("renderClaimsTable shows N/A for missing confidence", () => {
   }];
   const confidence = new Map<string, ConfidenceData>();
   const output = renderClaimsTable(claims, confidence);
-  assertEquals(output.includes("N/A"), true);
+  assertEquals(output.includes("─"), true);
 });
 
 Deno.test("renderClaimsTable shows score for known confidence", () => {

--- a/bin/lib/render.ts
+++ b/bin/lib/render.ts
@@ -93,7 +93,7 @@ function pad(str: string, width: number): string {
 }
 
 function formatScore(conf: ConfidenceData | undefined): string {
-  if (!conf) return colorize("  N/A  ", "unknown");
+  if (!conf || conf.computedAt === "") return `${GRAY}─${RESET}`;
   const score = conf.confidenceScore.toFixed(3);
   const level = confidenceLevel(conf.confidenceScore);
   return colorize(`● ${score}`, level);
@@ -175,7 +175,7 @@ function renderReadiness(
 
   for (const claim of activeClaims) {
     const conf = confidence.get(claim.claim_id);
-    if (!conf) {
+    if (!conf || conf.computedAt === "") {
       noDataCount++;
     } else if (claim.status === "contradicted") {
       contradictedCount++;

--- a/bin/rave-dashboard.ts
+++ b/bin/rave-dashboard.ts
@@ -96,6 +96,16 @@ async function main() {
   Deno.stdin.setRaw(true);
   draw(state);
 
+  // Auto-sweep on startup
+  drawWithStatus(state, "Running sweep: gathering evidence...");
+  const startupEvidenceOk = await runWorkflow("gather-all-evidence");
+  if (startupEvidenceOk) {
+    drawWithStatus(state, "Running sweep: computing confidence...");
+    await runWorkflow("confidence-decay-sweep");
+  }
+  state.confidence = await fetchAllConfidence(state.claims.map((c) => c.claim_id));
+  draw(state);
+
   const buf = new Uint8Array(8);
   try {
     while (true) {


### PR DESCRIPTION
## Summary

- Uncomputed claims (never evaluated) now render as `─` in gray instead of `● 0.000` in critical red, which was misleading — it implied a failed evaluation rather than no data
- Readiness summary now correctly counts uncomputed claims as "no data" rather than treating them as score 0
- The TUI automatically runs the full sweep (gather evidence → compute confidence) on every interactive startup, so scores reach reality immediately without having to press `s`

## Test plan

- [ ] First launch: claims briefly show `─`, then real scores appear after the auto-sweep completes
- [ ] Subsequent launches: existing scores shown initially, then refreshed by auto-sweep
- [ ] Readiness summary shows "N with no data" for uncomputed claims rather than counting them as below-threshold
- [ ] Manual `s` sweep still works normally after startup sweep completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)