### PR TITLE
Fix broken sweeps: rename reserved data name "latest" → "current"

### DIFF
--- a/bin/lib/render.ts
+++ b/bin/lib/render.ts
@@ -89,6 +89,9 @@ function pad(str: string, width: number): string {
   // deno-lint-ignore no-control-regex
   const visible = str.replace(/\x1b\[[0-9;]*m/g, "");
   const diff = width - visible.length;
+  if (diff < 0 && visible.length === str.length) {
+    return str.slice(0, width - 1) + "…";
+  }
   return diff > 0 ? str + " ".repeat(diff) : str;
 }
 

--- a/extensions/models/rave_ci_evidence.ts
+++ b/extensions/models/rave_ci_evidence.ts
@@ -61,7 +61,7 @@ export const model = {
           context.logger.warn(
             `Workflow '${workflowName}' not found in ${repo} — recording inconclusive`,
           );
-          const handle = await context.writeResource("result", "latest", {
+          const handle = await context.writeResource("result", "current", {
             outcome: "inconclusive",
             summary: `Workflow '${workflowName}' not found in ${repo}`,
             runId: "none",
@@ -91,7 +91,7 @@ export const model = {
           context.logger.warn(
             `No runs found for workflow '${workflowName}' on branch '${branch}'`,
           );
-          const handle = await context.writeResource("result", "latest", {
+          const handle = await context.writeResource("result", "current", {
             outcome: "inconclusive",
             summary:
               `No runs found for '${workflowName}' on branch '${branch}'`,
@@ -111,7 +111,7 @@ export const model = {
           `Run #${run.id}: status=${run.status} conclusion=${run.conclusion} → ${outcome}`,
         );
 
-        const handle = await context.writeResource("result", "latest", {
+        const handle = await context.writeResource("result", "current", {
           outcome,
           summary,
           runId: String(run.id),

--- a/extensions/models/rave_falsifier_engine.ts
+++ b/extensions/models/rave_falsifier_engine.ts
@@ -418,7 +418,7 @@ export const model = {
         // Read previous evaluation to preserve lastTriggeredAt
         let lastTriggeredAt: string | null = null;
         try {
-          const prev = await context.readResource("evaluation", "latest");
+          const prev = await context.readResource("evaluation", "current");
           if ((prev as { triggered: boolean }).triggered) {
             lastTriggeredAt = (prev as { evaluatedAt: string }).evaluatedAt;
           } else {
@@ -454,7 +454,7 @@ export const model = {
           );
         }
 
-        const handle = await context.writeResource("evaluation", "latest", {
+        const handle = await context.writeResource("evaluation", "current", {
           falsifierId,
           triggered: result.triggered,
           evaluatedAt,

--- a/extensions/models/rave_github_api_evidence.ts
+++ b/extensions/models/rave_github_api_evidence.ts
@@ -106,7 +106,7 @@ export const model = {
           context.logger.warn(
             `GitHub API request failed: ${message} — recording inconclusive`,
           );
-          const handle = await context.writeResource("result", "latest", {
+          const handle = await context.writeResource("result", "current", {
             outcome: "inconclusive",
             summary: `Request failed: ${message}`,
             rawData: "{}",
@@ -124,7 +124,7 @@ export const model = {
           context.logger.warn(
             `${evidenceId}: endpoint returned 404 — recording inconclusive`,
           );
-          const handle = await context.writeResource("result", "latest", {
+          const handle = await context.writeResource("result", "current", {
             outcome: "inconclusive",
             summary: `Endpoint not found: ${endpoint}`,
             rawData: bodyText,
@@ -176,7 +176,7 @@ export const model = {
           context.logger.info(`${evidenceId}: HTTP ${httpStatus} → pass`);
         }
 
-        const handle = await context.writeResource("result", "latest", {
+        const handle = await context.writeResource("result", "current", {
           outcome,
           summary,
           rawData,

--- a/extensions/models/rave_prometheus_evidence.ts
+++ b/extensions/models/rave_prometheus_evidence.ts
@@ -124,7 +124,7 @@ export const model = {
           context.logger.warn(
             `Prometheus request failed: ${message} — recording inconclusive`,
           );
-          const handle = await context.writeResource("result", "latest", {
+          const handle = await context.writeResource("result", "current", {
             outcome: "inconclusive",
             summary: `Query failed: ${message}`,
             value: null,
@@ -154,7 +154,7 @@ export const model = {
 
         if (value === null) {
           context.logger.warn(`No data returned for query: ${query}`);
-          const handle = await context.writeResource("result", "latest", {
+          const handle = await context.writeResource("result", "current", {
             outcome: "inconclusive",
             summary: buildSummary(query, null, unit ?? null, "inconclusive"),
             value: null,
@@ -179,7 +179,7 @@ export const model = {
           `Query value=${value}${unit ? " " + unit : ""} → ${outcome}`,
         );
 
-        const handle = await context.writeResource("result", "latest", {
+        const handle = await context.writeResource("result", "current", {
           outcome,
           summary: buildSummary(
             query,

--- a/extensions/models/rave_readiness_reporter.ts
+++ b/extensions/models/rave_readiness_reporter.ts
@@ -162,7 +162,7 @@ export const model = {
           }
         }
 
-        const handle = await context.writeResource("report", "latest", {
+        const handle = await context.writeResource("report", "current", {
           threshold,
           ready,
           evaluatedAt,

--- a/workflows/workflow-2da6b960-0b08-494b-95b6-6b21ee8f7e25.yaml
+++ b/workflows/workflow-2da6b960-0b08-494b-95b6-6b21ee8f7e25.yaml
@@ -19,11 +19,11 @@ jobs:
           inputs:
             evidence:
               - evidenceId: "evidence-github-branch-protection-001"
-                outcome: ${{ data.latest("evidence-github-branch-protection-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-github-branch-protection-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-github-branch-protection-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-github-branch-protection-001", "current").attributes.timestamp }}
                 freshnessWindow: "PT1H"
                 value: null
-                rawData: ${{ data.latest("evidence-github-branch-protection-001", "latest").attributes.rawData }}
+                rawData: ${{ data.latest("evidence-github-branch-protection-001", "current").attributes.rawData }}
   - name: ci-failure-on-main
     description: Evaluate falsifier-ci-failure-on-main-001 against GitHub Actions run history
     dependsOn: []
@@ -39,11 +39,11 @@ jobs:
           inputs:
             evidence:
               - evidenceId: "evidence-github-actions-runs-001"
-                outcome: ${{ data.latest("evidence-github-actions-runs-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-github-actions-runs-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-github-actions-runs-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-github-actions-runs-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 value: null
-                rawData: ${{ data.latest("evidence-github-actions-runs-001", "latest").attributes.rawData }}
+                rawData: ${{ data.latest("evidence-github-actions-runs-001", "current").attributes.rawData }}
   - name: model-validation-fail
     description: Evaluate falsifier-model-validation-fail-001 against swamp model validation CI evidence
     dependsOn: []
@@ -59,8 +59,8 @@ jobs:
           inputs:
             evidence:
               - evidenceId: "evidence-swamp-model-validate-001"
-                outcome: ${{ data.latest("evidence-swamp-model-validate-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-swamp-model-validate-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-swamp-model-validate-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-swamp-model-validate-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 value: null
                 rawData: null
@@ -79,8 +79,8 @@ jobs:
           inputs:
             evidence:
               - evidenceId: "evidence-swamp-workflow-validate-001"
-                outcome: ${{ data.latest("evidence-swamp-workflow-validate-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-swamp-workflow-validate-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-swamp-workflow-validate-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-swamp-workflow-validate-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 value: null
                 rawData: null
@@ -99,8 +99,8 @@ jobs:
           inputs:
             evidence:
               - evidenceId: "evidence-typescript-compile-001"
-                outcome: ${{ data.latest("evidence-typescript-compile-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-typescript-compile-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-typescript-compile-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-typescript-compile-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 value: null
                 rawData: null
@@ -119,8 +119,8 @@ jobs:
           inputs:
             evidence:
               - evidenceId: "evidence-lint-clean-001"
-                outcome: ${{ data.latest("evidence-lint-clean-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-lint-clean-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-lint-clean-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-lint-clean-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 value: null
                 rawData: null
@@ -139,8 +139,8 @@ jobs:
           inputs:
             evidence:
               - evidenceId: "evidence-unit-tests-pass-001"
-                outcome: ${{ data.latest("evidence-unit-tests-pass-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-unit-tests-pass-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-unit-tests-pass-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-unit-tests-pass-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 value: null
                 rawData: null
@@ -159,8 +159,8 @@ jobs:
           inputs:
             evidence:
               - evidenceId: "evidence-code-coverage-001"
-                outcome: ${{ data.latest("evidence-code-coverage-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-code-coverage-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-code-coverage-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-code-coverage-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 value: null
                 rawData: null
@@ -179,8 +179,8 @@ jobs:
           inputs:
             evidence:
               - evidenceId: "evidence-merged-prs-reviewed-001"
-                outcome: ${{ data.latest("evidence-merged-prs-reviewed-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-merged-prs-reviewed-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-merged-prs-reviewed-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-merged-prs-reviewed-001", "current").attributes.timestamp }}
                 freshnessWindow: "P2D"
                 value: null
                 rawData: null
@@ -199,8 +199,8 @@ jobs:
           inputs:
             evidence:
               - evidenceId: "evidence-no-secrets-committed-001"
-                outcome: ${{ data.latest("evidence-no-secrets-committed-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-no-secrets-committed-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-no-secrets-committed-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-no-secrets-committed-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 value: null
                 rawData: null
@@ -219,8 +219,8 @@ jobs:
           inputs:
             evidence:
               - evidenceId: "evidence-main-commits-via-pr-001"
-                outcome: ${{ data.latest("evidence-main-commits-via-pr-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-main-commits-via-pr-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-main-commits-via-pr-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-main-commits-via-pr-001", "current").attributes.timestamp }}
                 freshnessWindow: "P2D"
                 value: null
                 rawData: null
@@ -239,8 +239,8 @@ jobs:
           inputs:
             evidence:
               - evidenceId: "evidence-no-known-cves-001"
-                outcome: ${{ data.latest("evidence-no-known-cves-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-no-known-cves-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-no-known-cves-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-no-known-cves-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 value: null
                 rawData: null
@@ -259,8 +259,8 @@ jobs:
           inputs:
             evidence:
               - evidenceId: "evidence-no-stale-untriaged-issues-001"
-                outcome: ${{ data.latest("evidence-no-stale-untriaged-issues-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-no-stale-untriaged-issues-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-no-stale-untriaged-issues-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-no-stale-untriaged-issues-001", "current").attributes.timestamp }}
                 freshnessWindow: "P2D"
                 value: null
                 rawData: null
@@ -279,8 +279,8 @@ jobs:
           inputs:
             evidence:
               - evidenceId: "evidence-deno-lock-committed-001"
-                outcome: ${{ data.latest("evidence-deno-lock-committed-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-deno-lock-committed-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-deno-lock-committed-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-deno-lock-committed-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 value: null
                 rawData: null
@@ -299,8 +299,8 @@ jobs:
           inputs:
             evidence:
               - evidenceId: "evidence-npm-imports-pinned-001"
-                outcome: ${{ data.latest("evidence-npm-imports-pinned-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-npm-imports-pinned-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-npm-imports-pinned-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-npm-imports-pinned-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 value: null
                 rawData: null

--- a/workflows/workflow-fd0aacde-a1bc-46d1-bd64-3b1a8c239263.yaml
+++ b/workflows/workflow-fd0aacde-a1bc-46d1-bd64-3b1a8c239263.yaml
@@ -22,8 +22,8 @@ jobs:
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-github-branch-protection-001"
-                outcome: ${{ data.latest("evidence-github-branch-protection-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-github-branch-protection-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-github-branch-protection-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-github-branch-protection-001", "current").attributes.timestamp }}
                 freshnessWindow: "PT1H"
                 qualityScore: 1.0
   - name: ci-green
@@ -44,13 +44,13 @@ jobs:
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-ci-test-results-001"
-                outcome: ${{ data.latest("evidence-ci-test-results-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-ci-test-results-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-ci-test-results-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-ci-test-results-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.95
               - evidenceId: "evidence-github-actions-runs-001"
-                outcome: ${{ data.latest("evidence-github-actions-runs-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-github-actions-runs-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-github-actions-runs-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-github-actions-runs-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.9
   - name: swamp-models
@@ -71,8 +71,8 @@ jobs:
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-swamp-model-validate-001"
-                outcome: ${{ data.latest("evidence-swamp-model-validate-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-swamp-model-validate-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-swamp-model-validate-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-swamp-model-validate-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.98
   - name: swamp-workflows
@@ -93,8 +93,8 @@ jobs:
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-swamp-workflow-validate-001"
-                outcome: ${{ data.latest("evidence-swamp-workflow-validate-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-swamp-workflow-validate-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-swamp-workflow-validate-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-swamp-workflow-validate-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.98
   - name: extensions-compile
@@ -115,8 +115,8 @@ jobs:
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-typescript-compile-001"
-                outcome: ${{ data.latest("evidence-typescript-compile-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-typescript-compile-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-typescript-compile-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-typescript-compile-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.95
   - name: lint-clean
@@ -137,8 +137,8 @@ jobs:
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-lint-clean-001"
-                outcome: ${{ data.latest("evidence-lint-clean-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-lint-clean-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-lint-clean-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-lint-clean-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.95
   - name: unit-tests
@@ -159,8 +159,8 @@ jobs:
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-unit-tests-pass-001"
-                outcome: ${{ data.latest("evidence-unit-tests-pass-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-unit-tests-pass-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-unit-tests-pass-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-unit-tests-pass-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.95
   - name: code-coverage
@@ -181,8 +181,8 @@ jobs:
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-code-coverage-001"
-                outcome: ${{ data.latest("evidence-code-coverage-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-code-coverage-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-code-coverage-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-code-coverage-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.9
   - name: merged-prs-reviewed
@@ -203,8 +203,8 @@ jobs:
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-merged-prs-reviewed-001"
-                outcome: ${{ data.latest("evidence-merged-prs-reviewed-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-merged-prs-reviewed-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-merged-prs-reviewed-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-merged-prs-reviewed-001", "current").attributes.timestamp }}
                 freshnessWindow: "P2D"
                 qualityScore: 0.85
   - name: no-secrets
@@ -225,8 +225,8 @@ jobs:
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-no-secrets-committed-001"
-                outcome: ${{ data.latest("evidence-no-secrets-committed-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-no-secrets-committed-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-no-secrets-committed-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-no-secrets-committed-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.95
   - name: main-commits-via-pr
@@ -247,8 +247,8 @@ jobs:
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-main-commits-via-pr-001"
-                outcome: ${{ data.latest("evidence-main-commits-via-pr-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-main-commits-via-pr-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-main-commits-via-pr-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-main-commits-via-pr-001", "current").attributes.timestamp }}
                 freshnessWindow: "P2D"
                 qualityScore: 0.80
   - name: no-known-cves
@@ -269,8 +269,8 @@ jobs:
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-no-known-cves-001"
-                outcome: ${{ data.latest("evidence-no-known-cves-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-no-known-cves-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-no-known-cves-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-no-known-cves-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.90
   - name: no-stale-untriaged-issues
@@ -291,8 +291,8 @@ jobs:
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-no-stale-untriaged-issues-001"
-                outcome: ${{ data.latest("evidence-no-stale-untriaged-issues-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-no-stale-untriaged-issues-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-no-stale-untriaged-issues-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-no-stale-untriaged-issues-001", "current").attributes.timestamp }}
                 freshnessWindow: "P2D"
                 qualityScore: 0.85
   - name: deno-lock-committed
@@ -313,8 +313,8 @@ jobs:
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-deno-lock-committed-001"
-                outcome: ${{ data.latest("evidence-deno-lock-committed-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-deno-lock-committed-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-deno-lock-committed-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-deno-lock-committed-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.95
   - name: npm-imports-pinned
@@ -335,7 +335,7 @@ jobs:
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-npm-imports-pinned-001"
-                outcome: ${{ data.latest("evidence-npm-imports-pinned-001", "latest").attributes.outcome }}
-                timestamp: ${{ data.latest("evidence-npm-imports-pinned-001", "latest").attributes.timestamp }}
+                outcome: ${{ data.latest("evidence-npm-imports-pinned-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-npm-imports-pinned-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.95


### PR DESCRIPTION
## Summary

- Swamp now reserves the data name `"latest"` (it conflicts with the `data.latest(model, name)` CEL function). Every `gather` step was failing with `Data name 'latest' is reserved for internal use`, so no evidence was ever written — cascading into `confidence-decay-sweep` reading empty data and all claims staying at `─` in the dashboard even after running a manual sweep
- Renames `writeResource`/`readResource` calls from `"latest"` to `"current"` in all five affected models: `rave_ci_evidence`, `rave_github_api_evidence`, `rave_prometheus_evidence`, `rave_falsifier_engine`, `rave_readiness_reporter`
- Updates all `data.latest(<evidence>, "latest")` CEL expressions in `confidence-decay-sweep` and `falsifier-sweep` workflows to `"current"` (30 and ~45 sites respectively)
- Also truncates claim IDs that exceed the table column width in the dashboard to prevent layout overflow (`claim-no-stale-untriaged-issues-001` was 35 chars, 1 over the 34-char column)

## Test plan

- [ ] `swamp workflow run gather-all-evidence --json` — all `fetch` steps succeed (no more "reserved for internal use" errors)
- [ ] `swamp data get evidence-github-branch-protection-001 current --json` — returns real evidence data
- [ ] `swamp workflow run confidence-decay-sweep --json` — compute steps no longer fail on missing evidence
- [ ] TUI auto-sweep on startup produces real `● 0.xxx` scores for at least some claims
- [ ] `claim-no-stale-untriaged-issues-001` renders as `claim-no-stale-untriaged-issues-…` without overflowing the Status column

🤖 Generated with [Claude Code](https://claude.com/claude-code)