### PR TITLE
Fix confidence-decay-sweep failing on first run (No such key: attributes)

### DIFF
--- a/extensions/models/rave_confidence_engine.ts
+++ b/extensions/models/rave_confidence_engine.ts
@@ -117,8 +117,8 @@ export const model = {
       description:
         "Apply the RAVE decay formula to produce an updated confidence score for this claim",
       arguments: z.object({
-        currentScore: z.number(),
-        lastValidated: z.string(),
+        currentScore: z.number().optional(),
+        lastValidated: z.string().optional(),
         currentStatus: z.string(),
         evidence: z.array(EvidenceInputSchema),
       }),
@@ -127,14 +127,21 @@ export const model = {
         const now = new Date();
         const computedAt = now.toISOString();
 
-        // Read previous score for transition tracking
+        // Read prior record for previousScore tracking and optional arg defaults.
+        // Falls back to first-run defaults when no record exists yet.
         let previousScore: number | null = null;
+        let currentScore = args.currentScore ?? 1.0;
+        let lastValidated = args.lastValidated ?? computedAt;
         try {
-          const prev = await context.readResource("confidence", "current");
-          previousScore =
-            (prev as { confidenceScore: number }).confidenceScore ?? null;
+          const prev = await context.readResource("confidence", "current") as {
+            confidenceScore: number;
+            computedAt: string;
+          };
+          previousScore = prev.confidenceScore ?? null;
+          if (args.currentScore === undefined) currentScore = prev.confidenceScore ?? 1.0;
+          if (args.lastValidated === undefined) lastValidated = prev.computedAt ?? computedAt;
         } catch {
-          // No previous record — first run
+          // No previous record — first run, use defaults
         }
 
         // Skip computation for terminal/inactive statuses
@@ -152,7 +159,7 @@ export const model = {
             fAvg: 0.0,
             qAvg: 0.0,
             decayFactor: 1.0,
-            lastValidated: args.lastValidated,
+            lastValidated,
             computedAt,
             evidenceSnapshots: [],
             statusTransition: previousScore !== null && previousScore > 0
@@ -168,12 +175,12 @@ export const model = {
           );
           const handle = await context.writeResource("confidence", "current", {
             claimId,
-            confidenceScore: args.currentScore,
+            confidenceScore: currentScore,
             previousScore,
             fAvg: 1.0,
             qAvg: 1.0,
             decayFactor: 1.0,
-            lastValidated: args.lastValidated,
+            lastValidated,
             computedAt,
             evidenceSnapshots: [],
             statusTransition: null,
@@ -193,7 +200,7 @@ export const model = {
             fAvg: 0.0,
             qAvg: 0.0,
             decayFactor: 1.0,
-            lastValidated: args.lastValidated,
+            lastValidated,
             computedAt,
             evidenceSnapshots: [],
             statusTransition: null,
@@ -231,11 +238,11 @@ export const model = {
 
         // Decay: Δt in days
         const deltaDays =
-          (now.getTime() - new Date(args.lastValidated).getTime()) /
+          (now.getTime() - new Date(lastValidated).getTime()) /
           (1000 * 60 * 60 * 24);
         const decayFactor = Math.exp(-decayLambda * deltaDays);
 
-        let score = computeScore(args.currentScore, fAvg, qAvg, decayFactor);
+        let score = computeScore(currentScore, fAvg, qAvg, decayFactor);
 
         // Apply floor
         if (score > 0 && score < confidenceFloor) score = 0.0;
@@ -244,7 +251,7 @@ export const model = {
         score = Math.round(score * 10000) / 10000;
 
         context.logger.info(
-          `Claim '${claimId}': C₀=${args.currentScore} × F_avg=${
+          `Claim '${claimId}': C₀=${currentScore} × F_avg=${
             fAvg.toFixed(3)
           } × Q_avg=${qAvg.toFixed(3)} × decay=${
             decayFactor.toFixed(4)
@@ -263,7 +270,7 @@ export const model = {
           fAvg,
           qAvg,
           decayFactor,
-          lastValidated: args.lastValidated,
+          lastValidated,
           computedAt,
           evidenceSnapshots: snapshots,
           statusTransition,

--- a/workflows/workflow-fd0aacde-a1bc-46d1-bd64-3b1a8c239263.yaml
+++ b/workflows/workflow-fd0aacde-a1bc-46d1-bd64-3b1a8c239263.yaml
@@ -17,8 +17,6 @@ jobs:
           modelIdOrName: confidence-claim-branch-protection-001
           methodName: compute
           inputs:
-            currentScore: ${{ data.latest("confidence-claim-branch-protection-001", "current").attributes.confidenceScore }}
-            lastValidated: ${{ data.latest("confidence-claim-branch-protection-001", "current").attributes.computedAt }}
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-github-branch-protection-001"
@@ -39,8 +37,6 @@ jobs:
           modelIdOrName: confidence-claim-ci-green-on-main-001
           methodName: compute
           inputs:
-            currentScore: ${{ data.latest("confidence-claim-ci-green-on-main-001", "current").attributes.confidenceScore }}
-            lastValidated: ${{ data.latest("confidence-claim-ci-green-on-main-001", "current").attributes.computedAt }}
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-ci-test-results-001"
@@ -66,8 +62,6 @@ jobs:
           modelIdOrName: confidence-claim-swamp-models-valid-001
           methodName: compute
           inputs:
-            currentScore: ${{ data.latest("confidence-claim-swamp-models-valid-001", "current").attributes.confidenceScore }}
-            lastValidated: ${{ data.latest("confidence-claim-swamp-models-valid-001", "current").attributes.computedAt }}
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-swamp-model-validate-001"
@@ -88,8 +82,6 @@ jobs:
           modelIdOrName: confidence-claim-swamp-workflows-valid-001
           methodName: compute
           inputs:
-            currentScore: ${{ data.latest("confidence-claim-swamp-workflows-valid-001", "current").attributes.confidenceScore }}
-            lastValidated: ${{ data.latest("confidence-claim-swamp-workflows-valid-001", "current").attributes.computedAt }}
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-swamp-workflow-validate-001"
@@ -110,8 +102,6 @@ jobs:
           modelIdOrName: confidence-claim-extensions-compile-001
           methodName: compute
           inputs:
-            currentScore: ${{ data.latest("confidence-claim-extensions-compile-001", "current").attributes.confidenceScore }}
-            lastValidated: ${{ data.latest("confidence-claim-extensions-compile-001", "current").attributes.computedAt }}
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-typescript-compile-001"
@@ -132,8 +122,6 @@ jobs:
           modelIdOrName: confidence-claim-lint-clean-001
           methodName: compute
           inputs:
-            currentScore: ${{ data.latest("confidence-claim-lint-clean-001", "current").attributes.confidenceScore }}
-            lastValidated: ${{ data.latest("confidence-claim-lint-clean-001", "current").attributes.computedAt }}
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-lint-clean-001"
@@ -154,8 +142,6 @@ jobs:
           modelIdOrName: confidence-claim-unit-tests-pass-001
           methodName: compute
           inputs:
-            currentScore: ${{ data.latest("confidence-claim-unit-tests-pass-001", "current").attributes.confidenceScore }}
-            lastValidated: ${{ data.latest("confidence-claim-unit-tests-pass-001", "current").attributes.computedAt }}
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-unit-tests-pass-001"
@@ -176,8 +162,6 @@ jobs:
           modelIdOrName: confidence-claim-code-coverage-001
           methodName: compute
           inputs:
-            currentScore: ${{ data.latest("confidence-claim-code-coverage-001", "current").attributes.confidenceScore }}
-            lastValidated: ${{ data.latest("confidence-claim-code-coverage-001", "current").attributes.computedAt }}
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-code-coverage-001"
@@ -198,8 +182,6 @@ jobs:
           modelIdOrName: confidence-claim-merged-prs-reviewed-001
           methodName: compute
           inputs:
-            currentScore: ${{ data.latest("confidence-claim-merged-prs-reviewed-001", "current").attributes.confidenceScore }}
-            lastValidated: ${{ data.latest("confidence-claim-merged-prs-reviewed-001", "current").attributes.computedAt }}
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-merged-prs-reviewed-001"
@@ -220,8 +202,6 @@ jobs:
           modelIdOrName: confidence-claim-no-secrets-committed-001
           methodName: compute
           inputs:
-            currentScore: ${{ data.latest("confidence-claim-no-secrets-committed-001", "current").attributes.confidenceScore }}
-            lastValidated: ${{ data.latest("confidence-claim-no-secrets-committed-001", "current").attributes.computedAt }}
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-no-secrets-committed-001"
@@ -242,8 +222,6 @@ jobs:
           modelIdOrName: confidence-claim-main-commits-via-pr-001
           methodName: compute
           inputs:
-            currentScore: ${{ data.latest("confidence-claim-main-commits-via-pr-001", "current").attributes.confidenceScore }}
-            lastValidated: ${{ data.latest("confidence-claim-main-commits-via-pr-001", "current").attributes.computedAt }}
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-main-commits-via-pr-001"
@@ -264,8 +242,6 @@ jobs:
           modelIdOrName: confidence-claim-no-known-cves-001
           methodName: compute
           inputs:
-            currentScore: ${{ data.latest("confidence-claim-no-known-cves-001", "current").attributes.confidenceScore }}
-            lastValidated: ${{ data.latest("confidence-claim-no-known-cves-001", "current").attributes.computedAt }}
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-no-known-cves-001"
@@ -286,8 +262,6 @@ jobs:
           modelIdOrName: confidence-claim-no-stale-untriaged-issues-001
           methodName: compute
           inputs:
-            currentScore: ${{ data.latest("confidence-claim-no-stale-untriaged-issues-001", "current").attributes.confidenceScore }}
-            lastValidated: ${{ data.latest("confidence-claim-no-stale-untriaged-issues-001", "current").attributes.computedAt }}
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-no-stale-untriaged-issues-001"
@@ -308,8 +282,6 @@ jobs:
           modelIdOrName: confidence-claim-deno-lock-committed-001
           methodName: compute
           inputs:
-            currentScore: ${{ data.latest("confidence-claim-deno-lock-committed-001", "current").attributes.confidenceScore }}
-            lastValidated: ${{ data.latest("confidence-claim-deno-lock-committed-001", "current").attributes.computedAt }}
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-deno-lock-committed-001"
@@ -330,8 +302,6 @@ jobs:
           modelIdOrName: confidence-claim-npm-imports-pinned-001
           methodName: compute
           inputs:
-            currentScore: ${{ data.latest("confidence-claim-npm-imports-pinned-001", "current").attributes.confidenceScore }}
-            lastValidated: ${{ data.latest("confidence-claim-npm-imports-pinned-001", "current").attributes.computedAt }}
             currentStatus: "active"
             evidence:
               - evidenceId: "evidence-npm-imports-pinned-001"


### PR DESCRIPTION
## Summary

The `compute` step in `confidence-decay-sweep` was reading `currentScore` and `lastValidated` via CEL from each claim's stored confidence record. On first run no record exists, so `data.latest(..., "current").attributes` errors with `No such key: attributes` — every compute step failed with `allowedFailure: true`, silently.

**Fix:** Make `currentScore` and `lastValidated` optional in the engine schema. The model reads them from its own stored resource (the same `readResource("confidence", "current")` it already used for `previousScore` tracking), with sensible first-run defaults:
- `currentScore` → `1.0` (start optimistic; evidence pulls it down)
- `lastValidated` → `now` (Δt = 0, no initial decay)

Removes the redundant CEL inputs from all 15 jobs in `confidence-decay-sweep`.

## Test plan

- [ ] `swamp workflow run confidence-decay-sweep --json` — all `compute` steps succeed (no more "No such key: attributes")
- [ ] `swamp data get confidence-claim-branch-protection-001 current --json` — returns a real confidence record
- [ ] TUI auto-sweep on startup produces real `● 0.xxx` scores for all active claims
- [ ] Running the TUI a second time: scores carry through correctly (i.e. `previousScore` / trend arrows work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)