### PR TITLE
Fix confidence trend arrows (previousScore always null)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -11,5 +11,8 @@
     "dashboard": "deno run --allow-read --allow-run=swamp bin/rave-dashboard.ts",
     "dashboard:json": "deno run --allow-read --allow-run=swamp bin/rave-dashboard.ts --json",
     "dashboard:test": "deno test --allow-read bin/"
+  },
+  "imports": {
+    "@systeminit/swamp-testing": "jsr:@systeminit/swamp-testing@^0.20260424.9"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -2,10 +2,13 @@
   "version": "5",
   "specifiers": {
     "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/assert@1.0.19": "1.0.19",
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/yaml@1": "1.0.12",
+    "jsr:@systeminit/swamp-testing@~0.20260424.9": "0.20260424.9",
     "npm:yaml@2": "2.8.3",
-    "npm:zod@4": "4.3.6"
+    "npm:zod@4": "4.3.6",
+    "npm:zod@^4.3.6": "4.3.6"
   },
   "jsr": {
     "@std/assert@1.0.19": {
@@ -19,14 +22,27 @@
     },
     "@std/yaml@1.0.12": {
       "integrity": "7deabca4545bcedd07c5f69ea53acea71b8b4c67562f224e17b90d75944cb20c"
+    },
+    "@systeminit/swamp-testing@0.20260424.9": {
+      "integrity": "c2364e542bbb5f03cda94aaba070be8710c9533423bbb36c91bd12ce2a45bbc5",
+      "dependencies": [
+        "jsr:@std/assert@1.0.19",
+        "npm:zod@^4.3.6"
+      ]
     }
   },
   "npm": {
     "yaml@2.8.3": {
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "bin": true
     },
     "zod@4.3.6": {
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="
     }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@systeminit/swamp-testing@~0.20260424.9"
+    ]
   }
 }

--- a/extensions/models/rave_confidence_engine.test.ts
+++ b/extensions/models/rave_confidence_engine.test.ts
@@ -1,4 +1,6 @@
 import { assertEquals, assertThrows, assertAlmostEquals } from "jsr:@std/assert@1";
+import { createModelTestContext } from "@systeminit/swamp-testing";
+import { model } from "./rave_confidence_engine.ts";
 
 // ---------------------------------------------------------------------------
 // Re-implement the pure functions under test so we can test them without
@@ -113,4 +115,63 @@ Deno.test("computeScore: fail evidence → fAvg=0 → score=0", () => {
 Deno.test("computeScore: partial freshness (50% pass, 50% fail)", () => {
   // fAvg = 0.5 (one pass, one fail), qAvg=0.9, decay=1.0, C₀=0.8
   assertAlmostEquals(computeScore(0.8, 0.5, 0.9, 1.0), 0.36, 1e-9);
+});
+
+// ---------------------------------------------------------------------------
+// compute execute — previousScore propagation (regression)
+// ---------------------------------------------------------------------------
+
+const passEvidence = {
+  evidenceId: "evidence-test-001",
+  outcome: "pass" as const,
+  timestamp: new Date().toISOString(),
+  freshnessWindow: "P1D",
+  qualityScore: 1.0,
+};
+
+Deno.test("compute: previousScore is null on first run (no stored resource)", async () => {
+  const { context, getWrittenResources } = createModelTestContext({
+    globalArgs: { claimId: "claim-test-001", decayLambda: 0.05, confidenceFloor: 0.01 },
+    methodName: "compute",
+  });
+
+  await model.methods.compute.execute(
+    { currentStatus: "active", evidence: [passEvidence] },
+    context,
+  );
+
+  const written = getWrittenResources();
+  assertEquals(written.length, 1);
+  assertEquals(written[0].data.previousScore, null);
+});
+
+Deno.test("compute: previousScore is populated from stored resource on second run", async () => {
+  const priorComputedAt = "2026-04-29T10:00:00.000Z";
+  const { context, getWrittenResources } = createModelTestContext({
+    globalArgs: { claimId: "claim-test-001", decayLambda: 0.05, confidenceFloor: 0.01 },
+    methodName: "compute",
+    storedResources: {
+      current: {
+        claimId: "claim-test-001",
+        confidenceScore: 0.85,
+        previousScore: null,
+        fAvg: 1.0,
+        qAvg: 1.0,
+        decayFactor: 1.0,
+        lastValidated: priorComputedAt,
+        computedAt: priorComputedAt,
+        evidenceSnapshots: [],
+        statusTransition: null,
+      },
+    },
+  });
+
+  await model.methods.compute.execute(
+    { currentStatus: "active", evidence: [passEvidence] },
+    context,
+  );
+
+  const written = getWrittenResources();
+  assertEquals(written.length, 1);
+  assertEquals(written[0].data.previousScore, 0.85);
 });

--- a/extensions/models/rave_confidence_engine.ts
+++ b/extensions/models/rave_confidence_engine.ts
@@ -133,13 +133,17 @@ export const model = {
         let currentScore = args.currentScore ?? 1.0;
         let lastValidated = args.lastValidated ?? computedAt;
         try {
-          const prev = await context.readResource("confidence", "current") as {
+          const prev = await context.readResource("current") as {
             confidenceScore: number;
             computedAt: string;
           };
           previousScore = prev.confidenceScore ?? null;
-          if (args.currentScore === undefined) currentScore = prev.confidenceScore ?? 1.0;
-          if (args.lastValidated === undefined) lastValidated = prev.computedAt ?? computedAt;
+          if (args.currentScore === undefined) {
+            currentScore = prev.confidenceScore ?? 1.0;
+          }
+          if (args.lastValidated === undefined) {
+            lastValidated = prev.computedAt ?? computedAt;
+          }
         } catch {
           // No previous record — first run, use defaults
         }
@@ -237,8 +241,7 @@ export const model = {
         const qAvg = qSum / args.evidence.length;
 
         // Decay: Δt in days
-        const deltaDays =
-          (now.getTime() - new Date(lastValidated).getTime()) /
+        const deltaDays = (now.getTime() - new Date(lastValidated).getTime()) /
           (1000 * 60 * 60 * 24);
         const decayFactor = Math.exp(-decayLambda * deltaDays);
 
@@ -293,7 +296,7 @@ export const model = {
 
         let previousScore: number | null = null;
         try {
-          const prev = await context.readResource("confidence", "current");
+          const prev = await context.readResource("current");
           previousScore =
             (prev as { confidenceScore: number }).confidenceScore ?? null;
         } catch {

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,6 @@
 manifestVersion: 1
 name: "@mellens/rave"
-version: "2026.04.02.1"
+version: "2026.04.29.1"
 description: "RAVE (Reliability & Validation Engineering) — confidence scoring with exponential decay, claim lifecycle management, evidence gathering from GitHub and Prometheus, falsification detection, and readiness gating for software reliability claims"
 models:
   - rave_claim.ts


### PR DESCRIPTION
## Summary

- `context.readResource(specName, instanceName)` was called with wrong argument order — the API is `readResource(instanceName, version?)`, not `readResource(specName, instanceName)`. Passing `("confidence", "current")` looked for an instance named `"confidence"` (which doesn't exist), returned `null`, triggered a silent TypeError in the catch block, and left `previousScore = null` on every run.
- Fixed both `compute` and `revalidate` methods to call `readResource("current")`.
- Added two execute-level tests using `@systeminit/swamp-testing`: one verifying `previousScore` is `null` on first run, one verifying it's populated from the stored resource on subsequent runs.
- Bumps extension manifest to `2026.04.29.1`.

## Test plan

- [x] `deno test extensions/models/rave_confidence_engine.test.ts` — 19 passed, 0 failed
- [x] `swamp extension push` — pushed as `@mellens/rave 2026.04.29.1`
- [x] Two consecutive `swamp workflow run confidence-decay-sweep` runs — `previousScore` populated, `statusTransition` shows `0.855→0.791` on `ci-green-on-main`
- [x] TUI trend column will now show ↑/↓ when confidence changes between sweeps

🤖 Generated with [Claude Code](https://claude.com/claude-code)