### PR TITLE
Sort claims table by category

### DIFF
--- a/bin/lib/render.test.ts
+++ b/bin/lib/render.test.ts
@@ -184,6 +184,34 @@ Deno.test("renderClaimsTable shows no arrow for tiny trend diff (< 0.001)", () =
   assertEquals(output.includes("↓"), false);
 });
 
+// --- renderClaimsTable: sort order ---
+
+Deno.test("renderClaimsTable sorts rows by category alphabetically", () => {
+  const claims = [
+    makeClaim({ claim_id: "claim-z-001", category: "security" }),
+    makeClaim({ claim_id: "claim-a-001", category: "reliability" }),
+    makeClaim({ claim_id: "claim-m-001", category: "code_quality" }),
+  ];
+  const output = stripAnsi(renderClaimsTable(claims, new Map()));
+  const reliabilityPos = output.indexOf("reliability");
+  const codeQualityPos = output.indexOf("code_quality");
+  const securityPos = output.indexOf("security");
+  // code_quality < reliability < security alphabetically
+  assertEquals(codeQualityPos < reliabilityPos, true);
+  assertEquals(reliabilityPos < securityPos, true);
+});
+
+Deno.test("renderClaimsTable stable-sorts by claim_id within same category", () => {
+  const claims = [
+    makeClaim({ claim_id: "claim-b-001", category: "reliability" }),
+    makeClaim({ claim_id: "claim-a-001", category: "reliability" }),
+  ];
+  const output = stripAnsi(renderClaimsTable(claims, new Map()));
+  const posA = output.indexOf("claim-a-001");
+  const posB = output.indexOf("claim-b-001");
+  assertEquals(posA < posB, true);
+});
+
 // --- renderClaimsTable: column layout ---
 
 Deno.test("renderClaimsTable truncates claim IDs that exceed column width", () => {

--- a/bin/lib/render.ts
+++ b/bin/lib/render.ts
@@ -148,7 +148,10 @@ export function renderClaimsTable(
   if (claims.length === 0) {
     lines.push(`│ ${GRAY}${pad("No claims in this scope", W - 2)}${RESET}│`);
   } else {
-    for (const claim of claims) {
+    const sorted = [...claims].sort((a, b) =>
+      a.category.localeCompare(b.category) || a.claim_id.localeCompare(b.claim_id)
+    );
+    for (const claim of sorted) {
       const conf = confidence.get(claim.claim_id);
       const sc = statusColor(claim.status);
       const row = ` ${pad(claim.claim_id, COL.id)}${sc}${


### PR DESCRIPTION
## Summary

- Claims in the TUI table are now sorted by category (alphabetically), then by claim ID within the same category.
- Two new tests cover the sort order and stable secondary sort.

## Test plan

- [x] `deno test --allow-read bin/lib/render.test.ts` — 34 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)