### PR TITLE
Add failureReason/remediation to evidence model schemas

### DIFF
--- a/extensions/models/rave_ci_evidence.test.ts
+++ b/extensions/models/rave_ci_evidence.test.ts
@@ -1,0 +1,114 @@
+import { assertEquals, assertExists } from "jsr:@std/assert@1";
+import { createModelTestContext } from "@systeminit/swamp-testing";
+import { model } from "./rave_ci_evidence.ts";
+
+const BASE_GLOBAL_ARGS = {
+  evidenceId: "evidence-ci-test-001",
+  repo: "org/repo",
+  workflowName: "ci.yml",
+  branch: "main",
+};
+
+function makeRun(conclusion: string | null) {
+  return {
+    id: 12345,
+    name: "CI",
+    display_title: "CI",
+    status: "completed",
+    conclusion,
+    head_branch: "main",
+    head_sha: "abc1234def",
+    created_at: new Date().toISOString(),
+  };
+}
+
+function mockFetch(
+  status: number,
+  body: unknown,
+): () => Promise<Response> {
+  return () =>
+    Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+}
+
+Deno.test("ci-evidence: pass outcome → failureReason and remediation are null", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = mockFetch(200, {
+    workflow_runs: [makeRun("success")],
+  });
+  try {
+    const { context, getWrittenResources } = createModelTestContext({
+      globalArgs: BASE_GLOBAL_ARGS,
+      methodName: "gather",
+    });
+    await model.methods.gather.execute({ githubToken: "tok" }, context);
+    const [res] = getWrittenResources();
+    assertEquals(res.data.outcome, "pass");
+    assertEquals(res.data.failureReason, null);
+    assertEquals(res.data.remediation, null);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("ci-evidence: fail outcome → failureReason and remediation are non-null strings", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = mockFetch(200, {
+    workflow_runs: [makeRun("failure")],
+  });
+  try {
+    const { context, getWrittenResources } = createModelTestContext({
+      globalArgs: BASE_GLOBAL_ARGS,
+      methodName: "gather",
+    });
+    await model.methods.gather.execute({ githubToken: "tok" }, context);
+    const [res] = getWrittenResources();
+    assertEquals(res.data.outcome, "fail");
+    assertExists(res.data.failureReason);
+    assertExists(res.data.remediation);
+    assertEquals(typeof res.data.failureReason, "string");
+    assertEquals(typeof res.data.remediation, "string");
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("ci-evidence: inconclusive (no runs) → failureReason and remediation are null", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = mockFetch(200, { workflow_runs: [] });
+  try {
+    const { context, getWrittenResources } = createModelTestContext({
+      globalArgs: BASE_GLOBAL_ARGS,
+      methodName: "gather",
+    });
+    await model.methods.gather.execute({ githubToken: "tok" }, context);
+    const [res] = getWrittenResources();
+    assertEquals(res.data.outcome, "inconclusive");
+    assertEquals(res.data.failureReason, null);
+    assertEquals(res.data.remediation, null);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("ci-evidence: 404 (workflow not found) → failureReason and remediation are null", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = mockFetch(404, {});
+  try {
+    const { context, getWrittenResources } = createModelTestContext({
+      globalArgs: BASE_GLOBAL_ARGS,
+      methodName: "gather",
+    });
+    await model.methods.gather.execute({ githubToken: "tok" }, context);
+    const [res] = getWrittenResources();
+    assertEquals(res.data.outcome, "inconclusive");
+    assertEquals(res.data.failureReason, null);
+    assertEquals(res.data.remediation, null);
+  } finally {
+    globalThis.fetch = original;
+  }
+});

--- a/extensions/models/rave_ci_evidence.ts
+++ b/extensions/models/rave_ci_evidence.ts
@@ -14,6 +14,8 @@ const ResultSchema = z.object({
   timestamp: z.string(),
   isStale: z.boolean(),
   rawStatus: z.string(),
+  failureReason: z.string().nullable(),
+  remediation: z.string().nullable(),
 });
 
 function conclusionToOutcome(
@@ -68,6 +70,8 @@ export const model = {
             timestamp: new Date().toISOString(),
             isStale: false,
             rawStatus: "not_found",
+            failureReason: null,
+            remediation: null,
           });
           return { dataHandles: [handle] };
         }
@@ -99,6 +103,8 @@ export const model = {
             timestamp: new Date().toISOString(),
             isStale: false,
             rawStatus: "no_runs",
+            failureReason: null,
+            remediation: null,
           });
           return { dataHandles: [handle] };
         }
@@ -118,6 +124,10 @@ export const model = {
           timestamp: run.created_at,
           isStale: false,
           rawStatus: run.conclusion ?? run.status ?? "unknown",
+          failureReason: outcome === "fail" ? summary : null,
+          remediation: outcome === "fail"
+            ? `Check the Actions log for run #${run.id} at https://github.com/${repo}/actions/runs/${run.id}`
+            : null,
         });
 
         return { dataHandles: [handle] };

--- a/extensions/models/rave_github_api_evidence.test.ts
+++ b/extensions/models/rave_github_api_evidence.test.ts
@@ -1,0 +1,98 @@
+import { assertEquals, assertExists } from "jsr:@std/assert@1";
+import { createModelTestContext } from "@systeminit/swamp-testing";
+import { model } from "./rave_github_api_evidence.ts";
+
+const BASE_GLOBAL_ARGS = {
+  evidenceId: "evidence-test-001",
+  repo: "org/repo",
+  endpoint: "/branches/main/protection",
+  successField: "$.required_status_checks.strict",
+};
+
+function mockFetch(
+  status: number,
+  body: unknown,
+  ok?: boolean,
+): () => Promise<Response> {
+  return () =>
+    Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+}
+
+Deno.test("github-api-evidence: pass outcome → failureReason and remediation are null", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = mockFetch(200, { required_status_checks: { strict: true } });
+  try {
+    const { context, getWrittenResources } = createModelTestContext({
+      globalArgs: BASE_GLOBAL_ARGS,
+      methodName: "gather",
+    });
+    await model.methods.gather.execute({ githubToken: "tok" }, context);
+    const [res] = getWrittenResources();
+    assertEquals(res.data.outcome, "pass");
+    assertEquals(res.data.failureReason, null);
+    assertEquals(res.data.remediation, null);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("github-api-evidence: fail outcome → failureReason and remediation are non-null strings", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = mockFetch(200, { required_status_checks: { strict: false } });
+  try {
+    const { context, getWrittenResources } = createModelTestContext({
+      globalArgs: BASE_GLOBAL_ARGS,
+      methodName: "gather",
+    });
+    await model.methods.gather.execute({ githubToken: "tok" }, context);
+    const [res] = getWrittenResources();
+    assertEquals(res.data.outcome, "fail");
+    assertExists(res.data.failureReason);
+    assertExists(res.data.remediation);
+    assertEquals(typeof res.data.failureReason, "string");
+    assertEquals(typeof res.data.remediation, "string");
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("github-api-evidence: 404 endpoint → failureReason and remediation are null", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = mockFetch(404, {});
+  try {
+    const { context, getWrittenResources } = createModelTestContext({
+      globalArgs: BASE_GLOBAL_ARGS,
+      methodName: "gather",
+    });
+    await model.methods.gather.execute({ githubToken: "tok" }, context);
+    const [res] = getWrittenResources();
+    assertEquals(res.data.outcome, "inconclusive");
+    assertEquals(res.data.failureReason, null);
+    assertEquals(res.data.remediation, null);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("github-api-evidence: network error → failureReason and remediation are null", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = () => Promise.reject(new Error("network failure"));
+  try {
+    const { context, getWrittenResources } = createModelTestContext({
+      globalArgs: BASE_GLOBAL_ARGS,
+      methodName: "gather",
+    });
+    await model.methods.gather.execute({ githubToken: "tok" }, context);
+    const [res] = getWrittenResources();
+    assertEquals(res.data.outcome, "inconclusive");
+    assertEquals(res.data.failureReason, null);
+    assertEquals(res.data.remediation, null);
+  } finally {
+    globalThis.fetch = original;
+  }
+});

--- a/extensions/models/rave_github_api_evidence.test.ts
+++ b/extensions/models/rave_github_api_evidence.test.ts
@@ -12,7 +12,6 @@ const BASE_GLOBAL_ARGS = {
 function mockFetch(
   status: number,
   body: unknown,
-  ok?: boolean,
 ): () => Promise<Response> {
   return () =>
     Promise.resolve(

--- a/extensions/models/rave_github_api_evidence.ts
+++ b/extensions/models/rave_github_api_evidence.ts
@@ -18,6 +18,8 @@ const ResultSchema = z.object({
   timestamp: z.string(),
   isStale: z.boolean(),
   httpStatus: z.number(),
+  failureReason: z.string().nullable(),
+  remediation: z.string().nullable(),
 });
 
 // ---------------------------------------------------------------------------
@@ -113,6 +115,8 @@ export const model = {
             timestamp,
             isStale: false,
             httpStatus: 0,
+            failureReason: null,
+            remediation: null,
           });
           return { dataHandles: [handle] };
         }
@@ -131,6 +135,8 @@ export const model = {
             timestamp,
             isStale: false,
             httpStatus,
+            failureReason: null,
+            remediation: null,
           });
           return { dataHandles: [handle] };
         }
@@ -183,6 +189,12 @@ export const model = {
           timestamp,
           isStale: false,
           httpStatus,
+          failureReason: outcome === "fail" ? summary : null,
+          remediation: outcome === "fail"
+            ? `Check the API response for ${repo}${endpoint} and ensure ${
+              successField ?? "the endpoint"
+            } returns the expected value`
+            : null,
         });
 
         return { dataHandles: [handle] };

--- a/extensions/models/rave_prometheus_evidence.test.ts
+++ b/extensions/models/rave_prometheus_evidence.test.ts
@@ -1,0 +1,107 @@
+import { assertEquals, assertExists } from "jsr:@std/assert@1";
+import { createModelTestContext } from "@systeminit/swamp-testing";
+import { model } from "./rave_prometheus_evidence.ts";
+
+const BASE_GLOBAL_ARGS = {
+  evidenceId: "evidence-prom-test-001",
+  baseUrl: "http://prometheus.example.com",
+  query: "up",
+  threshold: 1,
+  operator: ">=" as const,
+};
+
+function scalarResponse(value: number) {
+  return {
+    status: "success",
+    data: { resultType: "scalar", result: [Date.now() / 1000, String(value)] },
+  };
+}
+
+function mockFetch(body: unknown, status = 200): () => Promise<Response> {
+  return () =>
+    Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+}
+
+Deno.test("prometheus-evidence: pass outcome → failureReason and remediation are null", async () => {
+  const original = globalThis.fetch;
+  // value=0.5, threshold=1, operator=">=" → 0.5>=1 false → evaluateThreshold=false → pass
+  globalThis.fetch = mockFetch(scalarResponse(0.5));
+  try {
+    const { context, getWrittenResources } = createModelTestContext({
+      globalArgs: { ...BASE_GLOBAL_ARGS, threshold: 1, operator: ">=" },
+      methodName: "gather",
+    });
+    await model.methods.gather.execute({ prometheusToken: "" }, context);
+    const [res] = getWrittenResources();
+    assertEquals(res.data.outcome, "pass");
+    assertEquals(res.data.failureReason, null);
+    assertEquals(res.data.remediation, null);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("prometheus-evidence: fail outcome → failureReason and remediation are non-null strings", async () => {
+  const original = globalThis.fetch;
+  // value=2, threshold=1, operator=">=" → 2>=1 true → evaluateThreshold=true → fail
+  globalThis.fetch = mockFetch(scalarResponse(2));
+  try {
+    const { context, getWrittenResources } = createModelTestContext({
+      globalArgs: { ...BASE_GLOBAL_ARGS, threshold: 1, operator: ">=" },
+      methodName: "gather",
+    });
+    await model.methods.gather.execute({ prometheusToken: "" }, context);
+    const [res] = getWrittenResources();
+    assertEquals(res.data.outcome, "fail");
+    assertExists(res.data.failureReason);
+    assertExists(res.data.remediation);
+    assertEquals(typeof res.data.failureReason, "string");
+    assertEquals(typeof res.data.remediation, "string");
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("prometheus-evidence: no data returned → failureReason and remediation are null", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = mockFetch({
+    status: "success",
+    data: { resultType: "vector", result: [] },
+  });
+  try {
+    const { context, getWrittenResources } = createModelTestContext({
+      globalArgs: BASE_GLOBAL_ARGS,
+      methodName: "gather",
+    });
+    await model.methods.gather.execute({ prometheusToken: "" }, context);
+    const [res] = getWrittenResources();
+    assertEquals(res.data.outcome, "inconclusive");
+    assertEquals(res.data.failureReason, null);
+    assertEquals(res.data.remediation, null);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+Deno.test("prometheus-evidence: network error → failureReason and remediation are null", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = () => Promise.reject(new Error("connection refused"));
+  try {
+    const { context, getWrittenResources } = createModelTestContext({
+      globalArgs: BASE_GLOBAL_ARGS,
+      methodName: "gather",
+    });
+    await model.methods.gather.execute({ prometheusToken: "" }, context);
+    const [res] = getWrittenResources();
+    assertEquals(res.data.outcome, "inconclusive");
+    assertEquals(res.data.failureReason, null);
+    assertEquals(res.data.remediation, null);
+  } finally {
+    globalThis.fetch = original;
+  }
+});

--- a/extensions/models/rave_prometheus_evidence.ts
+++ b/extensions/models/rave_prometheus_evidence.ts
@@ -17,6 +17,8 @@ const ResultSchema = z.object({
   timestamp: z.string(),
   isStale: z.boolean(),
   queryExecutedAt: z.string(),
+  failureReason: z.string().nullable(),
+  remediation: z.string().nullable(),
 });
 
 function extractValue(data: Record<string, unknown>): number | null {
@@ -132,6 +134,8 @@ export const model = {
             timestamp: queryExecutedAt,
             isStale: false,
             queryExecutedAt,
+            failureReason: null,
+            remediation: null,
           });
           return { dataHandles: [handle] };
         }
@@ -162,6 +166,8 @@ export const model = {
             timestamp: queryExecutedAt,
             isStale: false,
             queryExecutedAt,
+            failureReason: null,
+            remediation: null,
           });
           return { dataHandles: [handle] };
         }
@@ -179,21 +185,28 @@ export const model = {
           `Query value=${value}${unit ? " " + unit : ""} → ${outcome}`,
         );
 
+        const summary = buildSummary(
+          query,
+          value,
+          unit ?? null,
+          outcome,
+          operator,
+          threshold,
+        );
         const handle = await context.writeResource("result", "current", {
           outcome,
-          summary: buildSummary(
-            query,
-            value,
-            unit ?? null,
-            outcome,
-            operator,
-            threshold,
-          ),
+          summary,
           value,
           unit: unit ?? null,
           timestamp: queryExecutedAt,
           isStale: false,
           queryExecutedAt,
+          failureReason: outcome === "fail" ? summary : null,
+          remediation: outcome === "fail"
+            ? `Query returned ${value}${
+              unit ? " " + unit : ""
+            }; expected ${operator} ${threshold}. Investigate the metric source or adjust the alert threshold.`
+            : null,
         });
 
         return { dataHandles: [handle] };

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,6 @@
 manifestVersion: 1
 name: "@mellens/rave"
-version: "2026.04.29.1"
+version: "2026.04.29.2"
 description: "RAVE (Reliability & Validation Engineering) — confidence scoring with exponential decay, claim lifecycle management, evidence gathering from GitHub and Prometheus, falsification detection, and readiness gating for software reliability claims"
 models:
   - rave_claim.ts


### PR DESCRIPTION
Closes mesgme/rave-spec#135

## Summary

- Extends `ResultSchema` in `rave_ci_evidence`, `rave_github_api_evidence`, and `rave_prometheus_evidence` with `failureReason: string | null` and `remediation: string | null`.
- On `outcome === "fail"`, `failureReason` is set to the existing `summary` string and `remediation` provides a model-specific action hint (e.g. link to the failing Actions run, API endpoint to check, or metric threshold details).
- All `inconclusive` and `pass` paths write `null` for both fields.
- Adds 12 execute-level tests (4 per model) using `@systeminit/swamp-testing`.
- Bumps manifest to `2026.04.29.2`.

## Test plan

- [x] `deno test extensions/models/rave_ci_evidence.test.ts extensions/models/rave_github_api_evidence.test.ts extensions/models/rave_prometheus_evidence.test.ts` — 12 passed
- [x] `swamp extension push manifest.yaml -y` — pushed as `@mellens/rave 2026.04.29.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)