### PR TITLE
Aggregate evidence guidance in confidence engine

### DIFF
--- a/extensions/models/rave_confidence_engine.test.ts
+++ b/extensions/models/rave_confidence_engine.test.ts
@@ -145,6 +145,102 @@ Deno.test("compute: previousScore is null on first run (no stored resource)", as
   assertEquals(written[0].data.previousScore, null);
 });
 
+// ---------------------------------------------------------------------------
+// compute execute — guidance aggregation
+// ---------------------------------------------------------------------------
+
+Deno.test("compute: guidance is empty when all evidence passes", async () => {
+  const { context, getWrittenResources } = createModelTestContext({
+    globalArgs: { claimId: "claim-test-001", decayLambda: 0.05, confidenceFloor: 0.01 },
+    methodName: "compute",
+  });
+
+  await model.methods.compute.execute(
+    {
+      currentStatus: "active",
+      evidence: [{
+        ...passEvidence,
+        failureReason: null,
+        remediation: null,
+      }],
+    },
+    context,
+  );
+
+  const written = getWrittenResources();
+  assertEquals(written[0].data.guidance, []);
+});
+
+Deno.test("compute: guidance contains failureReason and remediation when evidence fails", async () => {
+  const { context, getWrittenResources } = createModelTestContext({
+    globalArgs: { claimId: "claim-test-001", decayLambda: 0.05, confidenceFloor: 0.01 },
+    methodName: "compute",
+  });
+
+  await model.methods.compute.execute(
+    {
+      currentStatus: "active",
+      evidence: [{
+        evidenceId: "evidence-fail-001",
+        outcome: "fail" as const,
+        timestamp: new Date().toISOString(),
+        freshnessWindow: "P1D",
+        qualityScore: 1.0,
+        failureReason: "CI run #999 failed on job 'test'",
+        remediation: "Check the Actions log at https://github.com/org/repo/actions/runs/999",
+      }],
+    },
+    context,
+  );
+
+  const written = getWrittenResources();
+  const guidance = written[0].data.guidance as string[];
+  assertEquals(guidance.length > 0, true);
+  assertEquals(guidance.some((g: string) => g.includes("CI run #999 failed")), true);
+  assertEquals(guidance.some((g: string) => g.includes("Check the Actions log")), true);
+});
+
+Deno.test("compute: guidance includes only failed evidence (not pass or inconclusive)", async () => {
+  const { context, getWrittenResources } = createModelTestContext({
+    globalArgs: { claimId: "claim-test-001", decayLambda: 0.05, confidenceFloor: 0.01 },
+    methodName: "compute",
+  });
+
+  await model.methods.compute.execute(
+    {
+      currentStatus: "active",
+      evidence: [
+        { ...passEvidence, evidenceId: "ev-pass", failureReason: null, remediation: null },
+        {
+          evidenceId: "ev-fail",
+          outcome: "fail" as const,
+          timestamp: new Date().toISOString(),
+          freshnessWindow: "P1D",
+          qualityScore: 1.0,
+          failureReason: "something broke",
+          remediation: "fix it",
+        },
+        {
+          evidenceId: "ev-inconclusive",
+          outcome: "inconclusive" as const,
+          timestamp: new Date().toISOString(),
+          freshnessWindow: null,
+          qualityScore: null,
+          failureReason: null,
+          remediation: null,
+        },
+      ],
+    },
+    context,
+  );
+
+  const written = getWrittenResources();
+  const guidance = written[0].data.guidance as string[];
+  assertEquals(guidance.some((g: string) => g.includes("something broke")), true);
+  assertEquals(guidance.some((g: string) => g.includes("fix it")), true);
+  assertEquals(guidance.length, 2); // failureReason + remediation from the one fail
+});
+
 Deno.test("compute: previousScore is populated from stored resource on second run", async () => {
   const priorComputedAt = "2026-04-29T10:00:00.000Z";
   const { context, getWrittenResources } = createModelTestContext({

--- a/extensions/models/rave_confidence_engine.ts
+++ b/extensions/models/rave_confidence_engine.ts
@@ -16,6 +16,8 @@ const EvidenceSnapshotSchema = z.object({
   isStale: z.boolean(),
   qualityScore: z.number(),
   freshnessContribution: z.number(),
+  failureReason: z.string().nullable(),
+  remediation: z.string().nullable(),
 });
 
 const ConfidenceSchema = z.object({
@@ -29,6 +31,7 @@ const ConfidenceSchema = z.object({
   computedAt: z.string(),
   evidenceSnapshots: z.array(EvidenceSnapshotSchema),
   statusTransition: z.string().nullable(),
+  guidance: z.array(z.string()),
 });
 
 const EvidenceInputSchema = z.object({
@@ -37,6 +40,8 @@ const EvidenceInputSchema = z.object({
   timestamp: z.string(),
   freshnessWindow: z.string().nullable(),
   qualityScore: z.number().nullable(),
+  failureReason: z.string().nullable().optional(),
+  remediation: z.string().nullable().optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -169,6 +174,7 @@ export const model = {
             statusTransition: previousScore !== null && previousScore > 0
               ? `${args.currentStatus}→0.0`
               : null,
+            guidance: [],
           });
           return { dataHandles: [handle] };
         }
@@ -188,6 +194,7 @@ export const model = {
             computedAt,
             evidenceSnapshots: [],
             statusTransition: null,
+            guidance: [],
           });
           return { dataHandles: [handle] };
         }
@@ -208,6 +215,7 @@ export const model = {
             computedAt,
             evidenceSnapshots: [],
             statusTransition: null,
+            guidance: [],
           });
           return { dataHandles: [handle] };
         }
@@ -234,6 +242,8 @@ export const model = {
             isStale: stale,
             qualityScore,
             freshnessContribution,
+            failureReason: ev.failureReason ?? null,
+            remediation: ev.remediation ?? null,
           });
         }
 
@@ -266,6 +276,12 @@ export const model = {
             ? `${previousScore.toFixed(3)}→${score.toFixed(3)}`
             : null;
 
+        const guidance: string[] = [];
+        for (const snap of snapshots) {
+          if (snap.failureReason) guidance.push(snap.failureReason);
+          if (snap.remediation) guidance.push(snap.remediation);
+        }
+
         const handle = await context.writeResource("confidence", "current", {
           claimId,
           confidenceScore: score,
@@ -277,6 +293,7 @@ export const model = {
           computedAt,
           evidenceSnapshots: snapshots,
           statusTransition,
+          guidance,
         });
 
         return { dataHandles: [handle] };
@@ -322,6 +339,7 @@ export const model = {
               args.newScore.toFixed(3)
             }`
             : null,
+          guidance: [],
         });
 
         return { dataHandles: [handle] };

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,6 @@
 manifestVersion: 1
 name: "@mellens/rave"
-version: "2026.04.29.2"
+version: "2026.04.29.3"
 description: "RAVE (Reliability & Validation Engineering) — confidence scoring with exponential decay, claim lifecycle management, evidence gathering from GitHub and Prometheus, falsification detection, and readiness gating for software reliability claims"
 models:
   - rave_claim.ts

--- a/workflows/workflow-fd0aacde-a1bc-46d1-bd64-3b1a8c239263.yaml
+++ b/workflows/workflow-fd0aacde-a1bc-46d1-bd64-3b1a8c239263.yaml
@@ -24,6 +24,8 @@ jobs:
                 timestamp: ${{ data.latest("evidence-github-branch-protection-001", "current").attributes.timestamp }}
                 freshnessWindow: "PT1H"
                 qualityScore: 1.0
+                failureReason: ${{ data.latest("evidence-github-branch-protection-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("evidence-github-branch-protection-001", "current").attributes.remediation }}
   - name: ci-green
     description: Recompute confidence for claim-ci-green-on-main-001
     dependsOn: []
@@ -44,11 +46,15 @@ jobs:
                 timestamp: ${{ data.latest("evidence-ci-test-results-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.95
+                failureReason: ${{ data.latest("evidence-ci-test-results-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("evidence-ci-test-results-001", "current").attributes.remediation }}
               - evidenceId: "evidence-github-actions-runs-001"
                 outcome: ${{ data.latest("evidence-github-actions-runs-001", "current").attributes.outcome }}
                 timestamp: ${{ data.latest("evidence-github-actions-runs-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.9
+                failureReason: ${{ data.latest("evidence-github-actions-runs-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("evidence-github-actions-runs-001", "current").attributes.remediation }}
   - name: swamp-models
     description: Recompute confidence for claim-swamp-models-valid-001
     dependsOn: []
@@ -69,6 +75,8 @@ jobs:
                 timestamp: ${{ data.latest("evidence-swamp-model-validate-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.98
+                failureReason: ${{ data.latest("evidence-swamp-model-validate-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("evidence-swamp-model-validate-001", "current").attributes.remediation }}
   - name: swamp-workflows
     description: Recompute confidence for claim-swamp-workflows-valid-001
     dependsOn: []
@@ -89,6 +97,8 @@ jobs:
                 timestamp: ${{ data.latest("evidence-swamp-workflow-validate-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.98
+                failureReason: ${{ data.latest("evidence-swamp-workflow-validate-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("evidence-swamp-workflow-validate-001", "current").attributes.remediation }}
   - name: extensions-compile
     description: Recompute confidence for claim-extensions-compile-001
     dependsOn: []
@@ -109,6 +119,8 @@ jobs:
                 timestamp: ${{ data.latest("evidence-typescript-compile-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.95
+                failureReason: ${{ data.latest("evidence-typescript-compile-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("evidence-typescript-compile-001", "current").attributes.remediation }}
   - name: lint-clean
     description: Recompute confidence for claim-lint-clean-001
     dependsOn: []
@@ -129,6 +141,8 @@ jobs:
                 timestamp: ${{ data.latest("evidence-lint-clean-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.95
+                failureReason: ${{ data.latest("evidence-lint-clean-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("evidence-lint-clean-001", "current").attributes.remediation }}
   - name: unit-tests
     description: Recompute confidence for claim-unit-tests-pass-001
     dependsOn: []
@@ -149,6 +163,8 @@ jobs:
                 timestamp: ${{ data.latest("evidence-unit-tests-pass-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.95
+                failureReason: ${{ data.latest("evidence-unit-tests-pass-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("evidence-unit-tests-pass-001", "current").attributes.remediation }}
   - name: code-coverage
     description: Recompute confidence for claim-code-coverage-001
     dependsOn: []
@@ -169,6 +185,8 @@ jobs:
                 timestamp: ${{ data.latest("evidence-code-coverage-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.9
+                failureReason: ${{ data.latest("evidence-code-coverage-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("evidence-code-coverage-001", "current").attributes.remediation }}
   - name: merged-prs-reviewed
     description: Recompute confidence for claim-merged-prs-reviewed-001
     dependsOn: []
@@ -189,6 +207,8 @@ jobs:
                 timestamp: ${{ data.latest("evidence-merged-prs-reviewed-001", "current").attributes.timestamp }}
                 freshnessWindow: "P2D"
                 qualityScore: 0.85
+                failureReason: ${{ data.latest("evidence-merged-prs-reviewed-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("evidence-merged-prs-reviewed-001", "current").attributes.remediation }}
   - name: no-secrets
     description: Recompute confidence for claim-no-secrets-committed-001
     dependsOn: []
@@ -209,6 +229,8 @@ jobs:
                 timestamp: ${{ data.latest("evidence-no-secrets-committed-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.95
+                failureReason: ${{ data.latest("evidence-no-secrets-committed-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("evidence-no-secrets-committed-001", "current").attributes.remediation }}
   - name: main-commits-via-pr
     description: Recompute confidence for claim-main-commits-via-pr-001
     dependsOn: []
@@ -229,6 +251,8 @@ jobs:
                 timestamp: ${{ data.latest("evidence-main-commits-via-pr-001", "current").attributes.timestamp }}
                 freshnessWindow: "P2D"
                 qualityScore: 0.80
+                failureReason: ${{ data.latest("evidence-main-commits-via-pr-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("evidence-main-commits-via-pr-001", "current").attributes.remediation }}
   - name: no-known-cves
     description: Recompute confidence for claim-no-known-cves-001
     dependsOn: []
@@ -249,6 +273,8 @@ jobs:
                 timestamp: ${{ data.latest("evidence-no-known-cves-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.90
+                failureReason: ${{ data.latest("evidence-no-known-cves-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("evidence-no-known-cves-001", "current").attributes.remediation }}
   - name: no-stale-untriaged-issues
     description: Recompute confidence for claim-no-stale-untriaged-issues-001
     dependsOn: []
@@ -269,6 +295,8 @@ jobs:
                 timestamp: ${{ data.latest("evidence-no-stale-untriaged-issues-001", "current").attributes.timestamp }}
                 freshnessWindow: "P2D"
                 qualityScore: 0.85
+                failureReason: ${{ data.latest("evidence-no-stale-untriaged-issues-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("evidence-no-stale-untriaged-issues-001", "current").attributes.remediation }}
   - name: deno-lock-committed
     description: Recompute confidence for claim-deno-lock-committed-001
     dependsOn: []
@@ -289,6 +317,8 @@ jobs:
                 timestamp: ${{ data.latest("evidence-deno-lock-committed-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.95
+                failureReason: ${{ data.latest("evidence-deno-lock-committed-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("evidence-deno-lock-committed-001", "current").attributes.remediation }}
   - name: npm-imports-pinned
     description: Recompute confidence for claim-npm-imports-pinned-001
     dependsOn: []
@@ -309,3 +339,5 @@ jobs:
                 timestamp: ${{ data.latest("evidence-npm-imports-pinned-001", "current").attributes.timestamp }}
                 freshnessWindow: "P1D"
                 qualityScore: 0.95
+                failureReason: ${{ data.latest("evidence-npm-imports-pinned-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("evidence-npm-imports-pinned-001", "current").attributes.remediation }}


### PR DESCRIPTION
Closes mesgme/rave-spec#136

Depends on #64 (issue A — merged first).

## Summary

- Extends `EvidenceSnapshotSchema` and `EvidenceInputSchema` in `rave_confidence_engine.ts` with `failureReason: string | null` and `remediation: string | null`.
- Adds `guidance: string[]` to `ConfidenceSchema`, populated inside `compute.execute` by collecting non-null `failureReason`/`remediation` from any failed evidence snapshots. All early-exit paths (`draft`, `contradicted`, `retired`, no-evidence) write `guidance: []`.
- Updates all 16 evidence inputs in `confidence-decay-sweep` workflow to read the new fields: `data.latest("evidence-…", "current").attributes.failureReason/remediation`.
- Adds 3 tests: empty guidance on pass, populated guidance on fail, only failed evidence contributes.
- Bumps manifest to `2026.04.29.3`.

## Test plan

- [x] `deno test extensions/models/rave_confidence_engine.test.ts` — 22 passed
- [x] `swamp extension push manifest.yaml -y` — pushed as `@mellens/rave 2026.04.29.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)