### PR TITLE
Surface guidance array in dashboard JSON output

### DIFF
--- a/bin/lib/confidence.test.ts
+++ b/bin/lib/confidence.test.ts
@@ -79,3 +79,42 @@ Deno.test("parseConfidenceResponse falls back to attributes key", () => {
   assertEquals(data?.claimId, "claim-legacy-001");
   assertEquals(data?.confidenceScore, 0.6);
 });
+
+Deno.test("parseConfidenceResponse extracts guidance array", () => {
+  const json = JSON.stringify({
+    content: {
+      claimId: "claim-test-001",
+      confidenceScore: 0.5,
+      previousScore: null,
+      computedAt: "2026-04-29T10:00:00Z",
+      lastValidated: "2026-04-29T10:00:00Z",
+      fAvg: 0.0,
+      qAvg: 1.0,
+      decayFactor: 1.0,
+      statusTransition: null,
+      guidance: ["CI run failed on job test", "Check the Actions log"],
+      evidenceSnapshots: [],
+    },
+  });
+  const data = parseConfidenceResponse(json);
+  assertEquals(data?.guidance, ["CI run failed on job test", "Check the Actions log"]);
+});
+
+Deno.test("parseConfidenceResponse defaults guidance to empty array when absent", () => {
+  const json = JSON.stringify({
+    content: {
+      claimId: "claim-test-001",
+      confidenceScore: 0.85,
+      previousScore: null,
+      computedAt: "2026-04-29T10:00:00Z",
+      lastValidated: "2026-04-29T10:00:00Z",
+      fAvg: 1.0,
+      qAvg: 1.0,
+      decayFactor: 1.0,
+      statusTransition: null,
+      evidenceSnapshots: [],
+    },
+  });
+  const data = parseConfidenceResponse(json);
+  assertEquals(data?.guidance, []);
+});

--- a/bin/lib/confidence.ts
+++ b/bin/lib/confidence.ts
@@ -17,6 +17,7 @@ export function parseConfidenceResponse(raw: string): ConfidenceData | null {
       qAvg: attrs.qAvg,
       decayFactor: attrs.decayFactor,
       statusTransition: attrs.statusTransition ?? null,
+      guidance: Array.isArray(attrs.guidance) ? attrs.guidance : [],
     };
   } catch {
     return null;
@@ -51,6 +52,7 @@ const ZERO_CONFIDENCE = (claimId: string): ConfidenceData => ({
   qAvg: 0,
   decayFactor: 0,
   statusTransition: null,
+  guidance: [],
 });
 
 /** Fetch confidence data for all claims in parallel. Claims with no data default to score 0. */

--- a/bin/lib/render.test.ts
+++ b/bin/lib/render.test.ts
@@ -35,6 +35,7 @@ function makeConfidence(overrides: Partial<ConfidenceData> = {}): ConfidenceData
     qAvg: 1.0,
     decayFactor: 1.0,
     statusTransition: null,
+    guidance: [],
     ...overrides,
   };
 }

--- a/bin/lib/types.ts
+++ b/bin/lib/types.ts
@@ -31,6 +31,7 @@ export interface ConfidenceData {
   qAvg: number;
   decayFactor: number;
   statusTransition: string | null;
+  guidance: string[];
 }
 
 /** Full dashboard state. */

--- a/bin/rave-dashboard.ts
+++ b/bin/rave-dashboard.ts
@@ -50,6 +50,7 @@ function outputJson(state: DashboardState) {
       previousScore: conf?.previousScore ?? null,
       computedAt: conf?.computedAt ?? null,
       level: conf ? confidenceLevel(conf.confidenceScore) : "unknown",
+      guidance: conf?.guidance ?? [],
     };
   });
   const scopes = state.flatScopes.map((s) => ({


### PR DESCRIPTION
## Summary
- Add `guidance: string[]` to `ConfidenceData` interface in `bin/lib/types.ts`
- Parse `guidance` from swamp API response in `parseConfidenceResponse` (defaults to `[]` when absent for backwards compatibility)
- Include `guidance` in each claim row in `outputJson` in `bin/rave-dashboard.ts`
- Update `makeConfidence` test fixture and add two new tests for guidance parsing

## Test plan
- [x] `parseConfidenceResponse extracts guidance array` — new test passes
- [x] `parseConfidenceResponse defaults guidance to empty array when absent` — new test passes
- [x] All 42 existing tests pass
- [x] `deno lint` clean

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)