### PR TITLE
Add rave-check CLI for agents and CI

### DIFF
--- a/bin/rave-check.test.ts
+++ b/bin/rave-check.test.ts
@@ -1,0 +1,102 @@
+import { assertEquals } from "jsr:@std/assert@1";
+import { checkClaims, type CheckResult } from "./rave-check.ts";
+import type { Claim, ConfidenceData } from "./lib/types.ts";
+
+function makeClaim(overrides: Partial<Claim> = {}): Claim {
+  return {
+    claim_id: "claim-test-001",
+    statement: "test claim",
+    status: "active",
+    category: "reliability",
+    scope: { type: "repository", target: "org/repo" },
+    scopeKey: "repository:org/repo",
+    decay_lambda: 0.05,
+    ...overrides,
+  };
+}
+
+function makeConfidence(overrides: Partial<ConfidenceData> = {}): ConfidenceData {
+  return {
+    claimId: "claim-test-001",
+    confidenceScore: 0.85,
+    previousScore: null,
+    computedAt: "2026-04-29T10:00:00Z",
+    lastValidated: "2026-04-29T10:00:00Z",
+    fAvg: 1.0,
+    qAvg: 1.0,
+    decayFactor: 1.0,
+    statusTransition: null,
+    guidance: [],
+    ...overrides,
+  };
+}
+
+Deno.test("checkClaims: ok=true when all active claims are above threshold with no guidance", () => {
+  const claims = [makeClaim({ claim_id: "c1" }), makeClaim({ claim_id: "c2" })];
+  const confidence = new Map([
+    ["c1", makeConfidence({ claimId: "c1", confidenceScore: 0.85 })],
+    ["c2", makeConfidence({ claimId: "c2", confidenceScore: 0.90 })],
+  ]);
+  const result = checkClaims(claims, confidence, 0.7);
+  assertEquals(result.ok, true);
+  assertEquals(result.claims.length, 0);
+});
+
+Deno.test("checkClaims: ok=false when a claim is below threshold", () => {
+  const claims = [makeClaim({ claim_id: "c1" }), makeClaim({ claim_id: "c2" })];
+  const confidence = new Map([
+    ["c1", makeConfidence({ claimId: "c1", confidenceScore: 0.85 })],
+    ["c2", makeConfidence({ claimId: "c2", confidenceScore: 0.50 })],
+  ]);
+  const result = checkClaims(claims, confidence, 0.7);
+  assertEquals(result.ok, false);
+  assertEquals(result.claims.length, 1);
+  assertEquals(result.claims[0].claimId, "c2");
+  assertEquals(result.claims[0].score, 0.50);
+});
+
+Deno.test("checkClaims: ok=false when a claim has non-empty guidance", () => {
+  const claims = [makeClaim({ claim_id: "c1" })];
+  const confidence = new Map([
+    ["c1", makeConfidence({
+      claimId: "c1",
+      confidenceScore: 0.85,
+      guidance: ["CI run failed on job test", "Check the Actions log"],
+    })],
+  ]);
+  const result = checkClaims(claims, confidence, 0.7);
+  assertEquals(result.ok, false);
+  assertEquals(result.claims.length, 1);
+  assertEquals(result.claims[0].guidance.length, 2);
+});
+
+Deno.test("checkClaims: non-active claims are excluded", () => {
+  const claims = [
+    makeClaim({ claim_id: "c1", status: "draft" }),
+    makeClaim({ claim_id: "c2", status: "retired" }),
+    makeClaim({ claim_id: "c3", status: "contradicted" }),
+  ];
+  const confidence = new Map([
+    ["c1", makeConfidence({ claimId: "c1", confidenceScore: 0.0 })],
+    ["c2", makeConfidence({ claimId: "c2", confidenceScore: 0.0 })],
+    ["c3", makeConfidence({ claimId: "c3", confidenceScore: 0.0 })],
+  ]);
+  const result = checkClaims(claims, confidence, 0.7);
+  assertEquals(result.ok, true);
+  assertEquals(result.claims.length, 0);
+});
+
+Deno.test("checkClaims: claim row includes level", () => {
+  const claims = [makeClaim({ claim_id: "c1" })];
+  const confidence = new Map([
+    ["c1", makeConfidence({ claimId: "c1", confidenceScore: 0.30 })],
+  ]);
+  const result = checkClaims(claims, confidence, 0.7);
+  assertEquals(result.claims[0].level, "low");
+});
+
+Deno.test("checkClaims: result type is CheckResult", () => {
+  const result: CheckResult = checkClaims([], new Map(), 0.7);
+  assertEquals(result.ok, true);
+  assertEquals(result.claims.length, 0);
+});

--- a/bin/rave-check.ts
+++ b/bin/rave-check.ts
@@ -1,0 +1,58 @@
+import { parseScopeFile, flattenScopes } from "./lib/scopes.ts";
+import { parseClaimFiles } from "./lib/claims.ts";
+import { fetchAllConfidence } from "./lib/confidence.ts";
+import { confidenceLevel } from "./lib/render.ts";
+import type { Claim, ConfidenceData, ConfidenceLevel } from "./lib/types.ts";
+
+export interface CheckClaimRow {
+  claimId: string;
+  score: number;
+  level: ConfidenceLevel;
+  guidance: string[];
+}
+
+export interface CheckResult {
+  ok: boolean;
+  claims: CheckClaimRow[];
+}
+
+/** Pure check logic — exported for unit testing. */
+export function checkClaims(
+  claims: Claim[],
+  confidence: Map<string, ConfidenceData>,
+  threshold: number,
+): CheckResult {
+  const failing: CheckClaimRow[] = [];
+
+  for (const claim of claims) {
+    if (claim.status !== "active") continue;
+
+    const conf = confidence.get(claim.claim_id);
+    const score = conf?.confidenceScore ?? 0;
+    const guidance = conf?.guidance ?? [];
+    const level = confidenceLevel(score);
+
+    if (score < threshold || guidance.length > 0) {
+      failing.push({ claimId: claim.claim_id, score, level, guidance });
+    }
+  }
+
+  return { ok: failing.length === 0, claims: failing };
+}
+
+async function main() {
+  const repoDir = Deno.args.find((a) => !a.startsWith("-")) ?? ".";
+  const threshold = 0.7;
+
+  const scopeTree = await parseScopeFile(`${repoDir}/rave/scopes/rave-swamp.yaml`);
+  const _flatScopes = flattenScopes(scopeTree);
+  const claims = await parseClaimFiles(`${repoDir}/rave/claims`);
+  const confidence = await fetchAllConfidence(claims.map((c) => c.claim_id));
+
+  const result = checkClaims(claims, confidence, threshold);
+
+  console.log(JSON.stringify(result, null, 2));
+  Deno.exit(result.ok ? 0 : 1);
+}
+
+if (import.meta.main) main();

--- a/deno.json
+++ b/deno.json
@@ -10,7 +10,8 @@
   "tasks": {
     "dashboard": "deno run --allow-read --allow-run=swamp bin/rave-dashboard.ts",
     "dashboard:json": "deno run --allow-read --allow-run=swamp bin/rave-dashboard.ts --json",
-    "dashboard:test": "deno test --allow-read bin/"
+    "dashboard:test": "deno test --allow-read bin/",
+    "check": "deno run --allow-read --allow-run=swamp bin/rave-check.ts"
   },
   "imports": {
     "@systeminit/swamp-testing": "jsr:@systeminit/swamp-testing@^0.20260424.9"


### PR DESCRIPTION
## Summary
- New `bin/rave-check.ts` CLI that reads all active claims and their confidence data
- Exits `0` when all claims are healthy (above threshold, no guidance); exits `1` otherwise
- Outputs structured JSON: `{ ok: bool, claims: [{ claimId, score, level, guidance: [...] }] }`
- `checkClaims()` is a pure exported function — fully unit-tested without swamp CLI
- Adds `deno task check` entry in `deno.json`

## Test plan
- [x] `checkClaims: ok=true when all active claims are above threshold with no guidance`
- [x] `checkClaims: ok=false when a claim is below threshold`
- [x] `checkClaims: ok=false when a claim has non-empty guidance`
- [x] `checkClaims: non-active claims are excluded`
- [x] `checkClaims: claim row includes level`
- [x] All 6 tests pass
- [x] `deno lint` clean

Depends on #66 (guidance field in ConfidenceData). Closes #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)