### PR TITLE
Add TUI guidance panel and claim navigation

### DIFF
--- a/bin/lib/render.test.ts
+++ b/bin/lib/render.test.ts
@@ -3,6 +3,7 @@ import {
   confidenceLevel,
   renderClaimsTable,
   renderDashboard,
+  renderGuidancePanel,
   renderReadiness,
   renderScopeTree,
   renderStatusLine,
@@ -346,6 +347,7 @@ function makeState(overrides: Partial<DashboardState> = {}): DashboardState {
     claims: [makeClaim({ scopeKey: "repository:org/repo" })],
     confidence: new Map(),
     selectedScopeIndex: 0,
+    selectedClaimId: null,
     threshold: 0.7,
     ...overrides,
   };
@@ -401,4 +403,68 @@ Deno.test("renderDashboard shows ─ for all uncomputed claims (regression)", ()
   const output = stripAnsi(renderDashboard(state));
   assertEquals(output.includes("0.000"), false);
   assertStringIncludes(output, "2 with no data");
+});
+
+// --- renderGuidancePanel ---
+
+Deno.test("renderGuidancePanel shows guidance lines", () => {
+  const output = renderGuidancePanel(["CI run failed", "Check the Actions log"]);
+  assertStringIncludes(stripAnsi(output), "CI run failed");
+  assertStringIncludes(stripAnsi(output), "Check the Actions log");
+});
+
+Deno.test("renderGuidancePanel returns empty string for empty guidance", () => {
+  const output = renderGuidancePanel([]);
+  assertEquals(output, "");
+});
+
+Deno.test("renderGuidancePanel includes a Guidance heading", () => {
+  const output = renderGuidancePanel(["some issue"]);
+  assertStringIncludes(stripAnsi(output), "Guidance");
+});
+
+// --- renderDashboard: guidance panel integration ---
+
+Deno.test("renderDashboard shows guidance panel when selected claim has guidance", () => {
+  const state = makeState({
+    claims: [makeClaim({ claim_id: "c1", scopeKey: "repository:org/repo" })],
+    confidence: new Map([
+      ["c1", makeConfidence({
+        claimId: "c1",
+        guidance: ["branch protection is disabled", "Enable required status checks"],
+      })],
+    ]),
+    selectedClaimId: "c1",
+  });
+  const output = stripAnsi(renderDashboard(state));
+  assertStringIncludes(output, "branch protection is disabled");
+  assertStringIncludes(output, "Enable required status checks");
+});
+
+Deno.test("renderDashboard omits guidance panel when selected claim has no guidance", () => {
+  const state = makeState({
+    claims: [makeClaim({ claim_id: "c1", scopeKey: "repository:org/repo" })],
+    confidence: new Map([
+      ["c1", makeConfidence({ claimId: "c1", guidance: [] })],
+    ]),
+    selectedClaimId: "c1",
+  });
+  const output = stripAnsi(renderDashboard(state));
+  assertStringIncludes(output, "RAVE Dashboard");
+  assertEquals(output.includes("Guidance"), false);
+});
+
+Deno.test("renderDashboard omits guidance panel when no claim is selected", () => {
+  const state = makeState({
+    claims: [makeClaim({ claim_id: "c1", scopeKey: "repository:org/repo" })],
+    confidence: new Map([
+      ["c1", makeConfidence({
+        claimId: "c1",
+        guidance: ["something failed"],
+      })],
+    ]),
+    selectedClaimId: null,
+  });
+  const output = stripAnsi(renderDashboard(state));
+  assertEquals(output.includes("Guidance"), false);
 });

--- a/bin/lib/render.ts
+++ b/bin/lib/render.ts
@@ -202,6 +202,18 @@ export function renderReadiness(
   return `${RED}${BOLD}Readiness: ✗ NOT READY${RESET} ${DIM}(${parts.join(", ")})${RESET}`;
 }
 
+// --- Guidance panel ---
+
+export function renderGuidancePanel(guidance: string[]): string {
+  if (guidance.length === 0) return "";
+  const lines: string[] = [];
+  lines.push(`  ${BOLD}${YELLOW}Guidance:${RESET}`);
+  for (const item of guidance) {
+    lines.push(`  ${DIM}•${RESET} ${item}`);
+  }
+  return lines.join("\n");
+}
+
 // --- Full dashboard ---
 
 export function renderStatusLine(message: string): string {
@@ -231,6 +243,16 @@ export function renderDashboard(state: DashboardState, statusMessage?: string): 
   lines.push(renderClaimsTable(filteredClaims, state.confidence));
   lines.push("");
 
+  // Guidance panel for selected claim
+  if (state.selectedClaimId !== null) {
+    const selectedConf = state.confidence.get(state.selectedClaimId);
+    const panel = renderGuidancePanel(selectedConf?.guidance ?? []);
+    if (panel) {
+      lines.push(panel);
+      lines.push("");
+    }
+  }
+
   // Readiness
   lines.push(`  ${renderReadiness(filteredClaims, state.confidence, state.threshold)}`);
   lines.push("");
@@ -243,7 +265,7 @@ export function renderDashboard(state: DashboardState, statusMessage?: string): 
 
   // Footer
   lines.push(
-    `  ${DIM}[↑/↓] Navigate scopes  [s] Sweep  [r] Refresh  [q] Quit${RESET}`,
+    `  ${DIM}[↑/↓] Navigate scopes  [j/k] Navigate claims  [s] Sweep  [r] Refresh  [q] Quit${RESET}`,
   );
   lines.push("");
 

--- a/bin/lib/types.ts
+++ b/bin/lib/types.ts
@@ -41,6 +41,7 @@ export interface DashboardState {
   claims: Claim[];
   confidence: Map<string, ConfidenceData>;
   selectedScopeIndex: number;
+  selectedClaimId: string | null;
   threshold: number;
 }
 

--- a/bin/rave-dashboard.ts
+++ b/bin/rave-dashboard.ts
@@ -1,5 +1,5 @@
 import { parseScopeFile, flattenScopes } from "./lib/scopes.ts";
-import { parseClaimFiles } from "./lib/claims.ts";
+import { parseClaimFiles, claimsForScope } from "./lib/claims.ts";
 import { fetchAllConfidence } from "./lib/confidence.ts";
 import { renderDashboard, confidenceLevel } from "./lib/render.ts";
 import type { DashboardState } from "./lib/types.ts";
@@ -34,6 +34,7 @@ async function loadState(repoDir: string, threshold: number): Promise<DashboardS
     claims,
     confidence,
     selectedScopeIndex: 0,
+    selectedClaimId: null,
     threshold,
   };
 }
@@ -121,14 +122,33 @@ async function main() {
       }
 
       if (input === "\x1b[A") {
-        // Up arrow
+        // Up arrow — navigate scopes
         state.selectedScopeIndex = Math.max(0, state.selectedScopeIndex - 1);
+        state.selectedClaimId = null;
       } else if (input === "\x1b[B") {
-        // Down arrow
+        // Down arrow — navigate scopes
         state.selectedScopeIndex = Math.min(
           state.flatScopes.length - 1,
           state.selectedScopeIndex + 1,
         );
+        state.selectedClaimId = null;
+      } else if (input === "j" || input === "k") {
+        // j/k — navigate claims within the selected scope
+        const selectedScope = state.flatScopes[state.selectedScopeIndex];
+        const scopeClaims = claimsForScope(state.claims, selectedScope)
+          .sort((a, b) => a.category.localeCompare(b.category) || a.claim_id.localeCompare(b.claim_id));
+        if (scopeClaims.length > 0) {
+          const currentIdx = state.selectedClaimId
+            ? scopeClaims.findIndex((c) => c.claim_id === state.selectedClaimId)
+            : -1;
+          if (input === "j") {
+            const next = Math.min(scopeClaims.length - 1, currentIdx + 1);
+            state.selectedClaimId = scopeClaims[next].claim_id;
+          } else {
+            const prev = Math.max(0, currentIdx <= 0 ? 0 : currentIdx - 1);
+            state.selectedClaimId = scopeClaims[prev].claim_id;
+          }
+        }
       } else if (input === "r") {
         // Refresh confidence data
         state.confidence = await fetchAllConfidence(


### PR DESCRIPTION
## Summary
- New `renderGuidancePanel(guidance: string[])` renders a formatted panel below the claims table when a claim with guidance is selected
- Add `selectedClaimId: string | null` to `DashboardState`
- `j`/`k` keys navigate claims within the selected scope; `↑`/`↓` reset claim selection when switching scopes
- Footer updated to show `[j/k] Navigate claims`
- Depends on #66 (guidance in ConfidenceData), #67 (rave-check)

## Test plan
- [x] `renderGuidancePanel shows guidance lines`
- [x] `renderGuidancePanel returns empty string for empty guidance`
- [x] `renderGuidancePanel includes a Guidance heading`
- [x] `renderDashboard shows guidance panel when selected claim has guidance`
- [x] `renderDashboard omits guidance panel when selected claim has no guidance`
- [x] `renderDashboard omits guidance panel when no claim is selected`
- [x] All 40 tests pass
- [x] `deno lint` clean

Closes #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)