### PR TITLE
Add diff-evidence model and tamper detection claim

### DIFF
--- a/extensions/models/rave_diff_evidence.test.ts
+++ b/extensions/models/rave_diff_evidence.test.ts
@@ -1,0 +1,92 @@
+import { assertEquals } from "jsr:@std/assert@1";
+import { classifyPaths } from "./rave_diff_evidence.ts";
+
+const GUARDED_GLOBS = [
+  "rave/claims/**",
+  "rave/scopes/**",
+  "workflows/workflow-*.yaml",
+  "extensions/models/rave_*.ts",
+];
+
+Deno.test("classifyPaths: no changes → pass", () => {
+  const result = classifyPaths([], GUARDED_GLOBS);
+  assertEquals(result.outcome, "pass");
+  assertEquals(result.guardedChanged, []);
+  assertEquals(result.nonGuardedChanged, []);
+});
+
+Deno.test("classifyPaths: only non-guarded changes → pass", () => {
+  const result = classifyPaths(["src/main.ts", "README.md"], GUARDED_GLOBS);
+  assertEquals(result.outcome, "pass");
+  assertEquals(result.nonGuardedChanged, ["src/main.ts", "README.md"]);
+  assertEquals(result.guardedChanged, []);
+});
+
+Deno.test("classifyPaths: only guarded changes → inconclusive", () => {
+  const result = classifyPaths(
+    ["rave/claims/claim-test-001.yaml", "extensions/models/rave_ci_evidence.ts"],
+    GUARDED_GLOBS,
+  );
+  assertEquals(result.outcome, "inconclusive");
+  assertEquals(result.guardedChanged.length, 2);
+  assertEquals(result.nonGuardedChanged, []);
+});
+
+Deno.test("classifyPaths: mixed guarded and non-guarded → fail", () => {
+  const result = classifyPaths(
+    ["rave/claims/claim-test-001.yaml", "src/app.ts"],
+    GUARDED_GLOBS,
+  );
+  assertEquals(result.outcome, "fail");
+  assertEquals(result.guardedChanged, ["rave/claims/claim-test-001.yaml"]);
+  assertEquals(result.nonGuardedChanged, ["src/app.ts"]);
+});
+
+Deno.test("classifyPaths: workflow yaml matches guarded glob", () => {
+  const result = classifyPaths(
+    ["workflows/workflow-abc123.yaml"],
+    GUARDED_GLOBS,
+  );
+  assertEquals(result.outcome, "inconclusive");
+  assertEquals(result.guardedChanged, ["workflows/workflow-abc123.yaml"]);
+});
+
+Deno.test("classifyPaths: rave_*.ts model file matches guarded glob", () => {
+  const result = classifyPaths(
+    ["extensions/models/rave_confidence_engine.ts"],
+    GUARDED_GLOBS,
+  );
+  assertEquals(result.outcome, "inconclusive");
+});
+
+Deno.test("classifyPaths: non-rave model file does not match guarded glob", () => {
+  const result = classifyPaths(
+    ["extensions/models/my_custom_model.ts"],
+    GUARDED_GLOBS,
+  );
+  assertEquals(result.outcome, "pass");
+});
+
+Deno.test("classifyPaths: rave/scopes matches guarded glob", () => {
+  const result = classifyPaths(
+    ["rave/scopes/rave-swamp.yaml", "bin/rave-dashboard.ts"],
+    GUARDED_GLOBS,
+  );
+  assertEquals(result.outcome, "fail");
+});
+
+Deno.test("classifyPaths: fail result has failureReason and remediation", () => {
+  const result = classifyPaths(
+    ["rave/claims/claim-test-001.yaml", "src/app.ts"],
+    GUARDED_GLOBS,
+  );
+  assertEquals(result.outcome, "fail");
+  assertEquals(typeof result.failureReason, "string");
+  assertEquals(typeof result.remediation, "string");
+});
+
+Deno.test("classifyPaths: pass result has null failureReason and remediation", () => {
+  const result = classifyPaths(["src/app.ts"], GUARDED_GLOBS);
+  assertEquals(result.failureReason, null);
+  assertEquals(result.remediation, null);
+});

--- a/extensions/models/rave_diff_evidence.ts
+++ b/extensions/models/rave_diff_evidence.ts
@@ -1,0 +1,182 @@
+import { z } from "npm:zod@4";
+
+const GlobalArgsSchema = z.object({
+  evidenceId: z.string(),
+  // Comma-delimited list of glob patterns, e.g. "rave/claims/**,rave/scopes/**"
+  guardedGlobs: z.string(),
+});
+
+const ResultSchema = z.object({
+  outcome: z.enum(["pass", "fail", "inconclusive"]),
+  summary: z.string(),
+  timestamp: z.string(),
+  isStale: z.boolean(),
+  failureReason: z.string().nullable(),
+  remediation: z.string().nullable(),
+  guardedChanged: z.array(z.string()),
+  nonGuardedChanged: z.array(z.string()),
+});
+
+// ---------------------------------------------------------------------------
+// Minimal glob matcher supporting * and ** wildcards.
+// ---------------------------------------------------------------------------
+
+function matchGlob(path: string, glob: string): boolean {
+  const regexStr = glob
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*\//g, "(.+/)?")
+    .replace(/\*\*/g, ".+")
+    .replace(/\*/g, "[^/]+");
+  return new RegExp(`^${regexStr}$`).test(path);
+}
+
+function isGuarded(path: string, globs: string[]): boolean {
+  return globs.some((g) => matchGlob(path, g));
+}
+
+// ---------------------------------------------------------------------------
+// Pure classification — exported for unit testing.
+// ---------------------------------------------------------------------------
+
+export interface ClassifyResult {
+  outcome: "pass" | "fail" | "inconclusive";
+  guardedChanged: string[];
+  nonGuardedChanged: string[];
+  failureReason: string | null;
+  remediation: string | null;
+}
+
+export function classifyPaths(
+  paths: string[],
+  guardedGlobs: string[],
+): ClassifyResult {
+  const guardedChanged: string[] = [];
+  const nonGuardedChanged: string[] = [];
+
+  for (const p of paths) {
+    if (isGuarded(p, guardedGlobs)) {
+      guardedChanged.push(p);
+    } else {
+      nonGuardedChanged.push(p);
+    }
+  }
+
+  if (guardedChanged.length === 0) {
+    return {
+      outcome: "pass",
+      guardedChanged,
+      nonGuardedChanged,
+      failureReason: null,
+      remediation: null,
+    };
+  }
+
+  if (nonGuardedChanged.length === 0) {
+    return {
+      outcome: "inconclusive",
+      guardedChanged,
+      nonGuardedChanged,
+      failureReason: null,
+      remediation: null,
+    };
+  }
+
+  const failureReason = `PR mixes rave spec changes (${
+    guardedChanged.join(", ")
+  }) with application changes (${nonGuardedChanged.join(", ")})`;
+  const remediation =
+    "Split this PR: one PR for the rave spec changes (add the 'rave: spec-change' label), another for application code.";
+
+  return {
+    outcome: "fail",
+    guardedChanged,
+    nonGuardedChanged,
+    failureReason,
+    remediation,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Model
+// ---------------------------------------------------------------------------
+
+export const model = {
+  type: "@mellens/rave/diff-evidence",
+  version: "2026.04.29.1",
+  globalArguments: GlobalArgsSchema,
+  resources: {
+    result: {
+      description: "Latest diff-based tamper evidence result",
+      schema: ResultSchema,
+      lifetime: "1d",
+      garbageCollection: 48,
+    },
+  },
+  methods: {
+    gather: {
+      description: "Run git diff to detect mixed spec+application PRs",
+      arguments: z.object({}),
+      execute: async (_args, context) => {
+        const { evidenceId } = context.globalArgs;
+        const guardedGlobs = context.globalArgs.guardedGlobs
+          .split(",")
+          .map((g) => g.trim())
+          .filter((g) => g.length > 0);
+        const timestamp = new Date().toISOString();
+
+        let diffOutput = "";
+        try {
+          const cmd = new Deno.Command("git", {
+            args: ["diff", "origin/main...HEAD", "--name-only"],
+            stdout: "piped",
+            stderr: "piped",
+          });
+          const output = await cmd.output();
+          diffOutput = new TextDecoder().decode(output.stdout);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          context.logger.warn(`${evidenceId}: git diff failed: ${message}`);
+          const handle = await context.writeResource("result", "current", {
+            outcome: "inconclusive",
+            summary: `git diff failed: ${message}`,
+            timestamp,
+            isStale: false,
+            failureReason: null,
+            remediation: null,
+            guardedChanged: [],
+            nonGuardedChanged: [],
+          });
+          return { dataHandles: [handle] };
+        }
+
+        const paths = diffOutput.split("\n").map((l) => l.trim()).filter((l) =>
+          l.length > 0
+        );
+        const classified = classifyPaths(paths, guardedGlobs);
+
+        const summary = classified.outcome === "pass"
+          ? `No guarded spec files changed (${paths.length} files total)`
+          : classified.outcome === "inconclusive"
+          ? `Only guarded spec files changed — pure spec PR (${classified.guardedChanged.length} files)`
+          : classified.failureReason!;
+
+        context.logger.info(
+          `${evidenceId}: ${summary} → ${classified.outcome}`,
+        );
+
+        const handle = await context.writeResource("result", "current", {
+          outcome: classified.outcome,
+          summary,
+          timestamp,
+          isStale: false,
+          failureReason: classified.failureReason,
+          remediation: classified.remediation,
+          guardedChanged: classified.guardedChanged,
+          nonGuardedChanged: classified.nonGuardedChanged,
+        });
+
+        return { dataHandles: [handle] };
+      },
+    },
+  },
+};

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,6 @@
 manifestVersion: 1
 name: "@mellens/rave"
-version: "2026.04.29.3"
+version: "2026.04.29.5"
 description: "RAVE (Reliability & Validation Engineering) — confidence scoring with exponential decay, claim lifecycle management, evidence gathering from GitHub and Prometheus, falsification detection, and readiness gating for software reliability claims"
 models:
   - rave_claim.ts
@@ -10,6 +10,7 @@ models:
   - rave_prometheus_evidence.ts
   - rave_falsifier_engine.ts
   - rave_readiness_reporter.ts
+  - rave_diff_evidence.ts
 labels:
   - rave
   - reliability

--- a/models/@mellens/rave/confidence-engine/8ad66b97-3a31-4a3f-ae3e-8f72e73fd90f.yaml
+++ b/models/@mellens/rave/confidence-engine/8ad66b97-3a31-4a3f-ae3e-8f72e73fd90f.yaml
@@ -1,0 +1,11 @@
+type: '@mellens/rave/confidence-engine'
+typeVersion: 2026.03.21.1
+id: 8ad66b97-3a31-4a3f-ae3e-8f72e73fd90f
+name: confidence-claim-rave-spec-untampered-001
+version: 1
+tags: {}
+globalArguments:
+  claimId: claim-rave-spec-untampered-001
+  decayLambda: 0.05
+  confidenceFloor: 0.01
+methods: {}

--- a/models/@mellens/rave/diff-evidence/cca325d8-cb1c-4875-aa57-2e43e11fe7bb.yaml
+++ b/models/@mellens/rave/diff-evidence/cca325d8-cb1c-4875-aa57-2e43e11fe7bb.yaml
@@ -1,0 +1,11 @@
+type: '@mellens/rave/diff-evidence'
+typeVersion: 2026.04.29.1
+id: cca325d8-cb1c-4875-aa57-2e43e11fe7bb
+name: evidence-rave-spec-untampered-001
+version: 1
+tags: {}
+globalArguments:
+  evidenceId: evidence-rave-spec-untampered-001
+  guardedGlobs: >-
+    rave/claims/**,rave/scopes/**,workflows/workflow-*.yaml,extensions/models/rave_*.ts
+methods: {}

--- a/rave/claims/claim-rave-spec-untampered-001.yaml
+++ b/rave/claims/claim-rave-spec-untampered-001.yaml
@@ -1,0 +1,16 @@
+claim_id: claim-rave-spec-untampered-001
+statement: No PR mixes rave spec changes with application code changes
+owner:
+  name: mellens
+  contact: mesgme/rave-swamp
+status: active
+category: governance
+scope:
+  type: repository
+  target: mesgme/rave-swamp
+assumptions:
+  - PRs are the standard unit of change for this repository
+  - git diff origin/main...HEAD accurately reflects the files changed in a PR
+falsification_signals:
+  - A PR contains changes to both rave spec files and application code files
+decay_lambda: 0.05

--- a/workflows/workflow-7ffc2c4d-9b41-481f-8e94-4aac697e70e3.yaml
+++ b/workflows/workflow-7ffc2c4d-9b41-481f-8e94-4aac697e70e3.yaml
@@ -227,4 +227,17 @@ jobs:
         allowFailure: true
     dependsOn: []
     weight: 0
+  - name: rave-spec-untampered
+    description: Gather diff-based tamper detection evidence for the rave spec
+    steps:
+      - name: fetch
+        description: Run git diff to classify guarded vs non-guarded file changes
+        task:
+          type: model_method
+          modelIdOrName: evidence-rave-spec-untampered-001
+          methodName: gather
+          inputs: {}
+        allowFailure: true
+    dependsOn: []
+    weight: 0
 version: 1

--- a/workflows/workflow-fd0aacde-a1bc-46d1-bd64-3b1a8c239263.yaml
+++ b/workflows/workflow-fd0aacde-a1bc-46d1-bd64-3b1a8c239263.yaml
@@ -341,3 +341,25 @@ jobs:
                 qualityScore: 0.95
                 failureReason: ${{ data.latest("evidence-npm-imports-pinned-001", "current").attributes.failureReason }}
                 remediation: ${{ data.latest("evidence-npm-imports-pinned-001", "current").attributes.remediation }}
+  - name: rave-spec-untampered
+    description: Recompute confidence for claim-rave-spec-untampered-001
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: compute
+        description: Apply RAVE decay formula with latest diff tamper evidence
+        allowFailure: true
+        task:
+          type: model_method
+          modelIdOrName: confidence-claim-rave-spec-untampered-001
+          methodName: compute
+          inputs:
+            currentStatus: "active"
+            evidence:
+              - evidenceId: "evidence-rave-spec-untampered-001"
+                outcome: ${{ data.latest("evidence-rave-spec-untampered-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-rave-spec-untampered-001", "current").attributes.timestamp }}
+                freshnessWindow: "P1D"
+                qualityScore: 0.95
+                failureReason: ${{ data.latest("evidence-rave-spec-untampered-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("evidence-rave-spec-untampered-001", "current").attributes.remediation }}


### PR DESCRIPTION
## Summary
- New `extensions/models/rave_diff_evidence.ts` with `gather` method that runs `git diff origin/main...HEAD --name-only` and classifies paths as guarded/non-guarded
- `outcome: pass` — no guarded spec files changed; `fail` — mixed PR (suspicious); `inconclusive` — pure spec change (needs human review)
- Guarded globs configured via comma-delimited `guardedGlobs` global arg
- New `rave/claims/claim-rave-spec-untampered-001.yaml` (category: governance)
- Model instances `evidence-rave-spec-untampered-001` and `confidence-claim-rave-spec-untampered-001` created
- Gather job added to `gather-all-evidence` workflow; compute job added to `confidence-decay-sweep`
- Extension pushed as `@mellens/rave` v2026.04.29.5

## Test plan
- [x] 10 unit tests for `classifyPaths` pure function
- [x] All 83 extension model tests pass
- [x] `deno lint` clean

Closes #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)