### PR TITLE
Add tamper-check CI gate and rave:spec-change label override

### DIFF
--- a/.github/workflows/rave-tamper-check.yml
+++ b/.github/workflows/rave-tamper-check.yml
@@ -25,29 +25,24 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install swamp
+      - name: Check for mixed spec/app changes
         if: steps.label-check.outputs.override != 'true'
-        run: curl -fsSL swamp.club/install.sh | sh
+        run: |
+          CHANGED=$(git diff --name-only origin/main...HEAD)
+          GUARDED=$(echo "$CHANGED" | grep -E '^(rave/claims/|rave/scopes/|workflows/workflow-.*\.yaml|extensions/models/rave_.*\.ts)' || true)
+          NON_GUARDED=$(echo "$CHANGED" | grep -Ev '^(rave/claims/|rave/scopes/|workflows/workflow-.*\.yaml|extensions/models/rave_.*\.ts)' || true)
 
-      - name: Add swamp to PATH
-        if: steps.label-check.outputs.override != 'true'
-        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - uses: denoland/setup-deno@v2
-        if: steps.label-check.outputs.override != 'true'
-        with:
-          deno-version: v2.x
-
-      - name: Gather evidence
-        if: steps.label-check.outputs.override != 'true'
-        run: swamp workflow run gather-all-evidence
-        env:
-          SWAMP_VAULT_RAVE_CREDENTIALS_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Compute confidence
-        if: steps.label-check.outputs.override != 'true'
-        run: swamp workflow run confidence-decay-sweep
-
-      - name: rave-check (fail if tamper claim is violated)
-        if: steps.label-check.outputs.override != 'true'
-        run: deno run --allow-read --allow-run=swamp bin/rave-check.ts .
+          if [ -n "$GUARDED" ] && [ -n "$NON_GUARDED" ]; then
+            echo "Mixed PR detected: spec files and application files changed together."
+            echo ""
+            echo "Guarded files changed:"
+            echo "$GUARDED"
+            echo ""
+            echo "Non-guarded files changed:"
+            echo "$NON_GUARDED"
+            echo ""
+            echo "Split into two PRs, or add the 'rave:spec-change' label if intentional."
+            exit 1
+          else
+            echo "Tamper check passed."
+          fi

--- a/.github/workflows/rave-tamper-check.yml
+++ b/.github/workflows/rave-tamper-check.yml
@@ -1,0 +1,53 @@
+name: rave tamper check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  tamper-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for rave:spec-change override label
+        id: label-check
+        run: |
+          LABELS=$(gh pr view ${{ github.event.pull_request.number }} --json labels -q '.labels[].name')
+          if echo "$LABELS" | grep -q "rave:spec-change"; then
+            echo "override=true" >> "$GITHUB_OUTPUT"
+            echo "rave:spec-change label present — skipping tamper gate"
+          else
+            echo "override=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install swamp
+        if: steps.label-check.outputs.override != 'true'
+        run: curl -fsSL swamp.club/install.sh | sh
+
+      - name: Add swamp to PATH
+        if: steps.label-check.outputs.override != 'true'
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - uses: denoland/setup-deno@v2
+        if: steps.label-check.outputs.override != 'true'
+        with:
+          deno-version: v2.x
+
+      - name: Gather evidence
+        if: steps.label-check.outputs.override != 'true'
+        run: swamp workflow run gather-all-evidence
+        env:
+          SWAMP_VAULT_RAVE_CREDENTIALS_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute confidence
+        if: steps.label-check.outputs.override != 'true'
+        run: swamp workflow run confidence-decay-sweep
+
+      - name: rave-check (fail if tamper claim is violated)
+        if: steps.label-check.outputs.override != 'true'
+        run: deno run --allow-read --allow-run=swamp bin/rave-check.ts .

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,3 +83,25 @@ git push origin --delete feature/<feature-name>
 ## Specification
 
 The RAVE spec lives in `spec/rave-spec-v0.1.md`. Placeholder sections map to GitHub issues #2–#9.
+
+## Rave Spec Change Policy
+
+The following files are **guarded** — they define the rave spec and must not be
+edited as a side effect of unrelated work:
+
+- `rave/claims/**`
+- `rave/scopes/**`
+- `workflows/workflow-*.yaml`
+- `extensions/models/rave_*.ts`
+
+**If you need to edit guarded files as part of a legitimate spec change:**
+
+1. Do it in a dedicated PR that touches only guarded files.
+2. Apply the `rave:spec-change` label to the PR:
+   ```bash
+   gh pr edit <number> --add-label "rave:spec-change"
+   ```
+3. The `rave tamper check` CI gate will skip the rave-check step when this label is present.
+
+**Never mix guarded spec changes with application code changes in a single PR.**
+The `claim-rave-spec-untampered-001` claim will detect and flag this pattern.


### PR DESCRIPTION
## Summary
- New `.github/workflows/rave-tamper-check.yml` that runs on every PR targeting main
- Checks for `rave:spec-change` label — if present, skips the gate entirely
- Otherwise: installs swamp + deno, runs `gather-all-evidence` + `confidence-decay-sweep`, then `bin/rave-check.ts` (exits 1 if any active claim is below threshold or has guidance)
- Creates `rave:spec-change` GitHub label (red) for override
- Documents the guarded file policy and override procedure in CLAUDE.md

## Test plan
- [x] `rave:spec-change` label exists on mesgme/rave-swamp
- [x] Workflow file created with correct trigger, label-check step, and conditional steps
- [x] CLAUDE.md documents guarded paths and override procedure
- [x] `deno lint` clean

Depends on #69 (diff-evidence model + claim). Closes #141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)