### PR TITLE
Add markdown PR-comment rave health report

### DIFF
--- a/.github/workflows/rave-tamper-check.yml
+++ b/.github/workflows/rave-tamper-check.yml
@@ -46,3 +46,29 @@ jobs:
           else
             echo "Tamper check passed."
           fi
+
+      - name: Install swamp
+        run: curl -fsSL swamp.club/install.sh | sh
+
+      - name: Add swamp to PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Gather evidence
+        continue-on-error: true
+        run: swamp workflow run gather-all-evidence
+        env:
+          SWAMP_VAULT_RAVE_CREDENTIALS_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute confidence
+        continue-on-error: true
+        run: swamp workflow run confidence-decay-sweep
+
+      - name: Post rave health report to PR
+        continue-on-error: true
+        run: deno run --allow-read --allow-run=deno,swamp,gh --allow-env --allow-net bin/rave-report.ts ${{ github.event.pull_request.number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bin/rave-report.test.ts
+++ b/bin/rave-report.test.ts
@@ -1,0 +1,77 @@
+import { assertEquals, assertStringIncludes } from "jsr:@std/assert@1";
+import { renderHealthReport } from "./rave-report.ts";
+
+const CLAIM_ROWS = [
+  {
+    claimId: "claim-ci-green-on-main-001",
+    status: "active",
+    category: "reliability",
+    scope: "pipeline:mesgme/rave-swamp/main",
+    confidenceScore: 0.62,
+    previousScore: null,
+    computedAt: "2026-04-30T10:00:00Z",
+    level: "medium",
+    guidance: ["CI run #12345 failed", "Check the Actions log"],
+  },
+  {
+    claimId: "claim-branch-protection-001",
+    status: "active",
+    category: "change_risk",
+    scope: "pipeline:mesgme/rave-swamp/main",
+    confidenceScore: 1.0,
+    previousScore: null,
+    computedAt: "2026-04-30T10:00:00Z",
+    level: "high",
+    guidance: [],
+  },
+];
+
+Deno.test("renderHealthReport contains the sentinel comment", () => {
+  const report = renderHealthReport(CLAIM_ROWS, 0.7);
+  assertStringIncludes(report, "<!-- rave-health -->");
+});
+
+Deno.test("renderHealthReport contains the heading", () => {
+  const report = renderHealthReport(CLAIM_ROWS, 0.7);
+  assertStringIncludes(report, "## rave health");
+});
+
+Deno.test("renderHealthReport includes each claim ID", () => {
+  const report = renderHealthReport(CLAIM_ROWS, 0.7);
+  assertStringIncludes(report, "claim-ci-green-on-main-001");
+  assertStringIncludes(report, "claim-branch-protection-001");
+});
+
+Deno.test("renderHealthReport marks below-threshold score with ⚠️", () => {
+  const report = renderHealthReport(CLAIM_ROWS, 0.7);
+  assertStringIncludes(report, "⚠️");
+});
+
+Deno.test("renderHealthReport marks healthy score with ✓", () => {
+  const report = renderHealthReport(CLAIM_ROWS, 0.7);
+  assertStringIncludes(report, "✓");
+});
+
+Deno.test("renderHealthReport shows below-threshold count", () => {
+  const report = renderHealthReport(CLAIM_ROWS, 0.7);
+  assertStringIncludes(report, "1 claim below threshold");
+});
+
+Deno.test("renderHealthReport shows guidance in details block", () => {
+  const report = renderHealthReport(CLAIM_ROWS, 0.7);
+  assertStringIncludes(report, "<details>");
+  assertStringIncludes(report, "CI run #12345 failed");
+  assertStringIncludes(report, "Check the Actions log");
+});
+
+Deno.test("renderHealthReport omits details block when no guidance", () => {
+  const noGuidanceRows = [{ ...CLAIM_ROWS[1] }];
+  const report = renderHealthReport(noGuidanceRows, 0.7);
+  assertEquals(report.includes("<details>"), false);
+});
+
+Deno.test("renderHealthReport shows all green message when healthy", () => {
+  const healthyRows = [{ ...CLAIM_ROWS[1] }];
+  const report = renderHealthReport(healthyRows, 0.7);
+  assertStringIncludes(report, "all claims");
+});

--- a/bin/rave-report.ts
+++ b/bin/rave-report.ts
@@ -1,0 +1,145 @@
+export interface ClaimRow {
+  claimId: string;
+  status: string;
+  category: string;
+  scope: string;
+  confidenceScore: number | null;
+  previousScore: number | null;
+  computedAt: string | null;
+  level: string;
+  guidance: string[];
+}
+
+/** Render a markdown rave health report with the sentinel comment. */
+export function renderHealthReport(claims: ClaimRow[], threshold: number): string {
+  const active = claims.filter((c) => c.status === "active");
+  const belowThreshold = active.filter(
+    (c) => c.confidenceScore !== null && c.confidenceScore < threshold,
+  );
+  const withGuidance = active.filter((c) => c.guidance.length > 0);
+
+  const lines: string[] = [];
+  lines.push("<!-- rave-health -->");
+  lines.push("## rave health report");
+  lines.push("");
+  lines.push("| Claim | Category | Score | Level |");
+  lines.push("|---|---|---|---|");
+
+  for (const claim of claims) {
+    if (claim.status !== "active") continue;
+    const score = claim.confidenceScore;
+    const isBelow = score !== null && score < threshold;
+    const scoreStr = score === null
+      ? "—"
+      : `${isBelow ? "⚠️ " : "✓ "}${score.toFixed(3)}`;
+    lines.push(`| ${claim.claimId} | ${claim.category} | ${scoreStr} | ${claim.level} |`);
+  }
+
+  lines.push("");
+
+  if (belowThreshold.length === 0 && withGuidance.length === 0) {
+    lines.push(`✅ all claims are healthy (threshold ${threshold.toFixed(2)})`);
+  } else {
+    if (belowThreshold.length > 0) {
+      lines.push(
+        `**${belowThreshold.length} claim${belowThreshold.length === 1 ? "" : "s"} below threshold (${threshold.toFixed(2)})**`,
+      );
+    }
+    if (withGuidance.length > 0) {
+      lines.push("");
+      lines.push("<details><summary>Guidance</summary>");
+      lines.push("");
+      for (const claim of withGuidance) {
+        lines.push(`**${claim.claimId}**`);
+        for (const item of claim.guidance) {
+          lines.push(`- ${item}`);
+        }
+        lines.push("");
+      }
+      lines.push("</details>");
+    }
+  }
+
+  return lines.join("\n");
+}
+
+async function main() {
+  const prNumber = Deno.env.get("PR_NUMBER") ?? Deno.args[0];
+  if (!prNumber) {
+    console.error("Usage: rave-report.ts <pr-number>  (or set PR_NUMBER env var)");
+    Deno.exit(1);
+  }
+
+  const repoDir = ".";
+  const threshold = 0.7;
+
+  // Read dashboard JSON
+  const dashCmd = new Deno.Command("deno", {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-run=swamp",
+      `${repoDir}/bin/rave-dashboard.ts`,
+      "--json",
+      repoDir,
+    ],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const dashOutput = await dashCmd.output();
+  if (!dashOutput.success) {
+    const err = new TextDecoder().decode(dashOutput.stderr);
+    console.error(`rave-dashboard.ts failed: ${err}`);
+    Deno.exit(1);
+  }
+
+  const dashboard = JSON.parse(new TextDecoder().decode(dashOutput.stdout));
+  const report = renderHealthReport(dashboard.claims as ClaimRow[], threshold);
+
+  // Post or update PR comment
+  const SENTINEL = "<!-- rave-health -->";
+
+  // Find existing comment
+  const listCmd = new Deno.Command("gh", {
+    args: ["pr", "view", prNumber, "--json", "comments", "-q", ".comments[] | @json"],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const listOutput = await listCmd.output();
+  const commentsText = new TextDecoder().decode(listOutput.stdout);
+
+  let existingCommentId: string | null = null;
+  for (const line of commentsText.split("\n").filter((l) => l.trim())) {
+    try {
+      const comment = JSON.parse(line);
+      if (comment.body?.includes(SENTINEL)) {
+        existingCommentId = String(comment.databaseId ?? comment.id);
+        break;
+      }
+    } catch {
+      // skip
+    }
+  }
+
+  if (existingCommentId) {
+    const editCmd = new Deno.Command("gh", {
+      args: ["api", `repos/{owner}/{repo}/issues/comments/${existingCommentId}`, "--method", "PATCH", "-f", `body=${report}`],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    await editCmd.output();
+    console.log(`Updated existing rave-health comment #${existingCommentId}`);
+  } else {
+    const postCmd = new Deno.Command("gh", {
+      args: ["pr", "comment", prNumber, "--body", report],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    await postCmd.output();
+    console.log("Posted new rave-health comment");
+  }
+
+  console.log(report);
+}
+
+if (import.meta.main) main();


### PR DESCRIPTION
## Summary
- New `bin/rave-report.ts` renders a markdown health report table with `⚠️`/`✓` score indicators, below-threshold count, and a collapsible `<details>` guidance block
- Finds and updates an existing `<!-- rave-health -->` sentinel comment on the PR, or posts a new one
- Pure `renderHealthReport()` function is fully unit-tested
- Wired as a final step in `rave-tamper-check.yml` — runs after rave-check passes

## Test plan
- [x] `renderHealthReport contains the sentinel comment`
- [x] `renderHealthReport marks below-threshold score with ⚠️`
- [x] `renderHealthReport marks healthy score with ✓`
- [x] `renderHealthReport shows guidance in details block`
- [x] `renderHealthReport omits details block when no guidance`
- [x] All 9 tests pass
- [x] `deno lint` clean

Depends on #70 (tamper-check workflow). Closes #142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)