### PR TITLE
Add CLAUDE.md rave back-pressure rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,3 +105,21 @@ edited as a side effect of unrelated work:
 
 **Never mix guarded spec changes with application code changes in a single PR.**
 The `claim-rave-spec-untampered-001` claim will detect and flag this pattern.
+
+## rave back-pressure
+
+Before declaring any task complete, run:
+
+```bash
+deno task check
+```
+
+If the exit code is non-zero:
+1. Show the user the `claims[].guidance` text for each failing claim.
+2. Do not mark the task complete until the failing claims are resolved or the user explicitly accepts the current state.
+
+If your changes touched any of the guarded paths listed in **Rave Spec Change Policy** above, apply the `rave:spec-change` label to the PR before it is merged:
+
+```bash
+gh pr edit <number> --add-label "rave:spec-change"
+```


### PR DESCRIPTION
## Summary
- New `## rave back-pressure` section in CLAUDE.md instructs agents to run `deno task check` before declaring a task complete
- Agents must surface `claims[].guidance` text for failing claims and not close the task until resolved (or user explicitly accepts)
- References the existing guarded-path spec change policy for the `rave:spec-change` label requirement

Note: `.claude/settings.json` permission rules for guarded paths are intentionally local-only (`.claude/` is gitignored) — the CLAUDE.md text is the binding agent instruction.

Depends on #71 (rave health report, carries the full chain). Closes #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)