### PR TITLE
Add tamper_guard toggle — disable in source repo, strict by default for adopters

### DIFF
--- a/.github/workflows/rave-tamper-check.yml
+++ b/.github/workflows/rave-tamper-check.yml
@@ -25,8 +25,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Read tamper-guard config
+        id: config
+        run: |
+          if [ -f rave/config.yaml ]; then
+            ENABLED=$(yq -r '.tamper_guard.enabled // true' rave/config.yaml)
+          else
+            ENABLED=true
+          fi
+          echo "enabled=$ENABLED" >> "$GITHUB_OUTPUT"
+          echo "tamper_guard.enabled = $ENABLED"
+
       - name: Check for mixed spec/app changes
-        if: steps.label-check.outputs.override != 'true'
+        if: steps.config.outputs.enabled == 'true' && steps.label-check.outputs.override != 'true'
         run: |
           CHANGED=$(git diff --name-only origin/main...HEAD)
           GUARDED=$(echo "$CHANGED" | grep -E '^(rave/claims/|rave/scopes/|workflows/workflow-.*\.yaml|extensions/models/rave_.*\.ts)' || true)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,22 +86,22 @@ The RAVE spec lives in `spec/rave-spec-v0.1.md`. Placeholder sections map to Git
 
 ## Rave Spec Change Policy
 
-The following files are **guarded** — they define the rave spec and must not be
-edited as a side effect of unrelated work:
+The following files are **guarded** — in downstream repos they define an imported rave spec and must not be edited as a side effect of unrelated work:
 
 - `rave/claims/**`
 - `rave/scopes/**`
 - `workflows/workflow-*.yaml`
 - `extensions/models/rave_*.ts`
 
-**If you need to edit guarded files as part of a legitimate spec change:**
+**This repo has `tamper_guard.enabled: false` in `rave/config.yaml`.** The tamper-check CI gate is disabled here because these files are application code in the source repo — modifying them is normal development. The guard is meaningful in downstream repos that *adopt* rave-swamp without building it.
+
+**If you are an adopter and need to edit guarded files:**
 
 1. Do it in a dedicated PR that touches only guarded files.
 2. Apply the `rave:spec-change` label to the PR:
    ```bash
    gh pr edit <number> --add-label "rave:spec-change"
    ```
-3. The `rave tamper check` CI gate will skip the rave-check step when this label is present.
+3. The `rave tamper check` CI gate will skip the diff check when this label is present.
 
-**Never mix guarded spec changes with application code changes in a single PR.**
-The `claim-rave-spec-untampered-001` claim will detect and flag this pattern.
+**To enable the tamper guard in a downstream repo:** copy `rave-tamper-check.yml` into `.github/workflows/` and either omit `rave/config.yaml` entirely (defaults to `enabled: true`) or set `tamper_guard.enabled: true`.

--- a/rave/config.yaml
+++ b/rave/config.yaml
@@ -1,0 +1,13 @@
+# rave/config.yaml — repo-level rave configuration
+#
+# tamper_guard.enabled controls whether the rave-tamper-check CI gate
+# enforces the "no mixed spec+app changes in a single PR" rule.
+#
+# Default (field absent or file missing): true — strict enforcement.
+# Set to false in the rave-swamp source repo itself, where spec files
+# are application code and modifying them alongside app code is normal.
+#
+# Downstream repos that adopt rave-swamp should omit this file entirely
+# (or keep enabled: true) to get the full protection.
+tamper_guard:
+  enabled: false


### PR DESCRIPTION
## Summary

- Adds `rave/config.yaml` with `tamper_guard.enabled: false` for the source repo
- Updates `rave-tamper-check.yml` to read the toggle via `yq` before the diff step
- Updates `CLAUDE.md` spec-change policy section to explain source vs adopter distinction

## Why

The rave-swamp source repo naturally mixes spec-file changes (`rave/claims/`, `extensions/models/rave_*.ts`, etc.) with application code on every feature PR — these *are* the application code here. The strict gate blocks legitimate development in the source repo while remaining correct for downstream adopters.

## Behavior

- Source repo (`tamper_guard.enabled: false`): diff step skipped, check always passes
- Adopter repo (no config or `enabled: true`): strict diff check enforced
- `rave:spec-change` label override still works in both cases

## Test plan

- [ ] CI passes on this PR (toggle is disabled, diff step skipped)
- [ ] After merge: open a PR touching a guarded file + non-guarded file → tamper-check passes (toggle disabled)
- [ ] Verify adopter path mentally: repo with no `rave/config.yaml` → `yq` returns `true` default → diff check runs

Closes mesgme/rave-spec#144

🤖 Generated with [Claude Code](https://claude.com/claude-code)