### PR TITLE
Set jobName on 13 CI evidence instances

### DIFF
--- a/models/@mellens/rave/ci-evidence/219157b2-08c1-4662-9804-e458cc8825a7.yaml
+++ b/models/@mellens/rave/ci-evidence/219157b2-08c1-4662-9804-e458cc8825a7.yaml
@@ -1,5 +1,5 @@
 type: "@mellens/rave/ci-evidence"
-typeVersion: 2026.03.21.1
+typeVersion: 2026.04.30.1
 id: 219157b2-08c1-4662-9804-e458cc8825a7
 name: evidence-lint-clean-001
 version: 1
@@ -9,4 +9,5 @@ globalArguments:
   repo: mesgme/rave-swamp
   workflowName: validate.yml
   branch: main
+  jobName: lint
 methods: {}

--- a/models/@mellens/rave/ci-evidence/34958b81-c77f-46e9-9fd8-3fc2232487b7.yaml
+++ b/models/@mellens/rave/ci-evidence/34958b81-c77f-46e9-9fd8-3fc2232487b7.yaml
@@ -1,5 +1,5 @@
 type: "@mellens/rave/ci-evidence"
-typeVersion: 2026.03.21.1
+typeVersion: 2026.04.30.1
 id: 34958b81-c77f-46e9-9fd8-3fc2232487b7
 name: evidence-typescript-compile-001
 version: 1
@@ -9,4 +9,5 @@ globalArguments:
   repo: mesgme/rave-swamp
   workflowName: validate.yml
   branch: main
+  jobName: compile
 methods: {}

--- a/models/@mellens/rave/ci-evidence/44285dcc-234c-482c-bcb6-1970d71196b5.yaml
+++ b/models/@mellens/rave/ci-evidence/44285dcc-234c-482c-bcb6-1970d71196b5.yaml
@@ -1,5 +1,5 @@
 type: '@mellens/rave/ci-evidence'
-typeVersion: 2026.03.21.1
+typeVersion: 2026.04.30.1
 id: 44285dcc-234c-482c-bcb6-1970d71196b5
 name: evidence-no-secrets-committed-001
 version: 1
@@ -9,4 +9,5 @@ globalArguments:
   repo: mesgme/rave-swamp
   workflowName: validate.yml
   branch: main
+  jobName: secrets
 methods: {}

--- a/models/@mellens/rave/ci-evidence/52b47d41-2a67-47b4-9bb4-3e78c5a56500.yaml
+++ b/models/@mellens/rave/ci-evidence/52b47d41-2a67-47b4-9bb4-3e78c5a56500.yaml
@@ -1,5 +1,5 @@
 type: "@mellens/rave/ci-evidence"
-typeVersion: 2026.03.21.1
+typeVersion: 2026.04.30.1
 id: 52b47d41-2a67-47b4-9bb4-3e78c5a56500
 name: evidence-swamp-model-validate-001
 version: 1
@@ -9,4 +9,5 @@ globalArguments:
   repo: mesgme/rave-swamp
   workflowName: validate.yml
   branch: main
+  jobName: swamp-models
 methods: {}

--- a/models/@mellens/rave/ci-evidence/55e6b3a2-a737-43e5-9a4a-61db70300ae1.yaml
+++ b/models/@mellens/rave/ci-evidence/55e6b3a2-a737-43e5-9a4a-61db70300ae1.yaml
@@ -1,5 +1,5 @@
 type: "@mellens/rave/ci-evidence"
-typeVersion: 2026.03.21.1
+typeVersion: 2026.04.30.1
 id: 55e6b3a2-a737-43e5-9a4a-61db70300ae1
 name: evidence-unit-tests-pass-001
 version: 1
@@ -9,4 +9,5 @@ globalArguments:
   repo: mesgme/rave-swamp
   workflowName: validate.yml
   branch: main
+  jobName: unit-tests
 methods: {}

--- a/models/@mellens/rave/ci-evidence/5d666c84-3a3d-45be-8148-6ed0df3b921f.yaml
+++ b/models/@mellens/rave/ci-evidence/5d666c84-3a3d-45be-8148-6ed0df3b921f.yaml
@@ -1,5 +1,5 @@
 type: '@mellens/rave/ci-evidence'
-typeVersion: 2026.03.21.1
+typeVersion: 2026.04.30.1
 id: 5d666c84-3a3d-45be-8148-6ed0df3b921f
 name: evidence-main-commits-via-pr-001
 version: 1
@@ -9,4 +9,5 @@ globalArguments:
   repo: mesgme/rave-swamp
   workflowName: governance-check.yml
   branch: main
+  jobName: commits-via-pr
 methods: {}

--- a/models/@mellens/rave/ci-evidence/5d76e0bf-71ae-4adf-81da-e8ac66bf26fe.yaml
+++ b/models/@mellens/rave/ci-evidence/5d76e0bf-71ae-4adf-81da-e8ac66bf26fe.yaml
@@ -1,5 +1,5 @@
 type: "@mellens/rave/ci-evidence"
-typeVersion: 2026.03.21.1
+typeVersion: 2026.04.30.1
 id: 5d76e0bf-71ae-4adf-81da-e8ac66bf26fe
 name: evidence-ci-test-results-001
 version: 1

--- a/models/@mellens/rave/ci-evidence/69af0d0e-dfe0-466f-a26d-bf334d4948d3.yaml
+++ b/models/@mellens/rave/ci-evidence/69af0d0e-dfe0-466f-a26d-bf334d4948d3.yaml
@@ -1,5 +1,5 @@
 type: "@mellens/rave/ci-evidence"
-typeVersion: 2026.03.21.1
+typeVersion: 2026.04.30.1
 id: 69af0d0e-dfe0-466f-a26d-bf334d4948d3
 name: evidence-swamp-workflow-validate-001
 version: 1
@@ -9,4 +9,5 @@ globalArguments:
   repo: mesgme/rave-swamp
   workflowName: validate.yml
   branch: main
+  jobName: swamp-workflows
 methods: {}

--- a/models/@mellens/rave/ci-evidence/7e44a26d-2b2e-46a4-8277-46b5f3ac8814.yaml
+++ b/models/@mellens/rave/ci-evidence/7e44a26d-2b2e-46a4-8277-46b5f3ac8814.yaml
@@ -1,5 +1,5 @@
 type: "@mellens/rave/ci-evidence"
-typeVersion: 2026.03.21.1
+typeVersion: 2026.04.30.1
 id: 7e44a26d-2b2e-46a4-8277-46b5f3ac8814
 name: evidence-code-coverage-001
 version: 1
@@ -9,4 +9,5 @@ globalArguments:
   repo: mesgme/rave-swamp
   workflowName: validate.yml
   branch: main
+  jobName: coverage
 methods: {}

--- a/models/@mellens/rave/ci-evidence/907d7e0c-854e-4dde-9278-918d125e1004.yaml
+++ b/models/@mellens/rave/ci-evidence/907d7e0c-854e-4dde-9278-918d125e1004.yaml
@@ -1,5 +1,5 @@
 type: '@mellens/rave/ci-evidence'
-typeVersion: 2026.03.21.1
+typeVersion: 2026.04.30.1
 id: 907d7e0c-854e-4dde-9278-918d125e1004
 name: evidence-deno-lock-committed-001
 version: 1
@@ -9,4 +9,5 @@ globalArguments:
   repo: mesgme/rave-swamp
   workflowName: validate.yml
   branch: main
+  jobName: lock-file
 methods: {}

--- a/models/@mellens/rave/ci-evidence/9f3804d7-c457-43e7-ab0e-f702f8717e5e.yaml
+++ b/models/@mellens/rave/ci-evidence/9f3804d7-c457-43e7-ab0e-f702f8717e5e.yaml
@@ -1,5 +1,5 @@
 type: '@mellens/rave/ci-evidence'
-typeVersion: 2026.03.21.1
+typeVersion: 2026.04.30.1
 id: 9f3804d7-c457-43e7-ab0e-f702f8717e5e
 name: evidence-npm-imports-pinned-001
 version: 1
@@ -9,4 +9,5 @@ globalArguments:
   repo: mesgme/rave-swamp
   workflowName: validate.yml
   branch: main
+  jobName: npm-pins
 methods: {}

--- a/models/@mellens/rave/ci-evidence/d756d759-379f-425d-869a-af95fb85cdb7.yaml
+++ b/models/@mellens/rave/ci-evidence/d756d759-379f-425d-869a-af95fb85cdb7.yaml
@@ -1,5 +1,5 @@
 type: '@mellens/rave/ci-evidence'
-typeVersion: 2026.03.21.1
+typeVersion: 2026.04.30.1
 id: d756d759-379f-425d-869a-af95fb85cdb7
 name: evidence-merged-prs-reviewed-001
 version: 1
@@ -9,4 +9,5 @@ globalArguments:
   repo: mesgme/rave-swamp
   workflowName: governance-check.yml
   branch: main
+  jobName: pr-reviews
 methods: {}

--- a/models/@mellens/rave/ci-evidence/d7ef007e-4b56-4629-a8a9-572c02a086ea.yaml
+++ b/models/@mellens/rave/ci-evidence/d7ef007e-4b56-4629-a8a9-572c02a086ea.yaml
@@ -1,5 +1,5 @@
 type: '@mellens/rave/ci-evidence'
-typeVersion: 2026.03.21.1
+typeVersion: 2026.04.30.1
 id: d7ef007e-4b56-4629-a8a9-572c02a086ea
 name: evidence-no-known-cves-001
 version: 1
@@ -9,4 +9,5 @@ globalArguments:
   repo: mesgme/rave-swamp
   workflowName: validate.yml
   branch: main
+  jobName: cve-scan
 methods: {}

--- a/models/@mellens/rave/ci-evidence/ebeb91f5-6937-4eb5-9574-b48e5e5b5782.yaml
+++ b/models/@mellens/rave/ci-evidence/ebeb91f5-6937-4eb5-9574-b48e5e5b5782.yaml
@@ -1,5 +1,5 @@
 type: '@mellens/rave/ci-evidence'
-typeVersion: 2026.03.21.1
+typeVersion: 2026.04.30.1
 id: ebeb91f5-6937-4eb5-9574-b48e5e5b5782
 name: evidence-no-stale-untriaged-issues-001
 version: 1
@@ -9,4 +9,5 @@ globalArguments:
   repo: mesgme/rave-swamp
   workflowName: governance-check.yml
   branch: main
+  jobName: stale-untriaged-issues
 methods: {}


### PR DESCRIPTION
## Summary

- Sets `jobName` on 13 of 14 `@mellens/rave/ci-evidence` instances so each queries its specific job conclusion rather than the overall `validate.yml` workflow outcome
- Bumps `typeVersion` from `2026.03.21.1` → `2026.04.30.1` on all 14 instances

## Instance → jobName mapping

| Instance | jobName | Workflow |
|---|---|---|
| `evidence-no-secrets-committed-001` | `secrets` | validate.yml |
| `evidence-no-known-cves-001` | `cve-scan` | validate.yml |
| `evidence-swamp-model-validate-001` | `swamp-models` | validate.yml |
| `evidence-swamp-workflow-validate-001` | `swamp-workflows` | validate.yml |
| `evidence-deno-lock-committed-001` | `lock-file` | validate.yml |
| `evidence-npm-imports-pinned-001` | `npm-pins` | validate.yml |
| `evidence-typescript-compile-001` | `compile` | validate.yml |
| `evidence-lint-clean-001` | `lint` | validate.yml |
| `evidence-unit-tests-pass-001` | `unit-tests` | validate.yml |
| `evidence-code-coverage-001` | `coverage` | validate.yml |
| `evidence-merged-prs-reviewed-001` | `pr-reviews` | governance-check.yml |
| `evidence-main-commits-via-pr-001` | `commits-via-pr` | governance-check.yml |
| `evidence-no-stale-untriaged-issues-001` | `stale-untriaged-issues` | governance-check.yml |
| `evidence-ci-test-results-001` | *(unset)* | validate.yml — stays workflow-level for `claim-ci-green-on-main-001` |

## Test plan

- [ ] CI passes on this PR (tamper guard skipped, validate jobs all green)
- [ ] After merge, run `gather-all-evidence` and verify each claim shows its specific job outcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)