### PR TITLE
Migrate rave-swamp dataset to RAVE v0.2 (mechanical)

### DIFF
--- a/bin/lib/claims.ts
+++ b/bin/lib/claims.ts
@@ -7,7 +7,9 @@ interface RawClaim {
   status: string;
   category: string;
   scope: { type: string; target: string };
-  decay_lambda: number;
+  confidence?: { decay_lambda?: number };
+  /** @deprecated v0.1 top-level field; v0.2 uses confidence.decay_lambda */
+  decay_lambda?: number;
 }
 
 /** Parse a single claim YAML string into a Claim. */
@@ -20,7 +22,7 @@ export function parseClaimYaml(yamlStr: string): Claim {
     category: raw.category,
     scope: raw.scope,
     scopeKey: `${raw.scope.type}:${raw.scope.target}`,
-    decay_lambda: raw.decay_lambda,
+    decay_lambda: raw.confidence?.decay_lambda ?? raw.decay_lambda ?? 0,
   };
 }
 

--- a/rave/claims/claim-branch-protection-001.yaml
+++ b/rave/claims/claim-branch-protection-001.yaml
@@ -1,3 +1,4 @@
+rave_version: "0.2.0"
 claim_id: claim-branch-protection-001
 statement: The main branch requires a pull request before any commit can be merged
 owner:
@@ -16,7 +17,8 @@ falsification_signals:
   - Branch protection is disabled or removed from main
   - required_pull_request_reviews is null or missing from protection settings
   - A commit appears on main that is not associated with a merged pull request
-decay_lambda: 0.02
+confidence:
+  decay_lambda: 0.02
 annotations:
   - text: Validated during initial setup. Branch protection confirmed active.
     author: mellens

--- a/rave/claims/claim-ci-green-on-main-001.yaml
+++ b/rave/claims/claim-ci-green-on-main-001.yaml
@@ -1,3 +1,4 @@
+rave_version: "0.2.0"
 claim_id: claim-ci-green-on-main-001
 statement: All GitHub Actions workflow runs on the main branch succeed
 owner:
@@ -14,5 +15,6 @@ assumptions:
 falsification_signals:
   - Any workflow run on main has conclusion 'failure' or 'timed_out'
   - No workflow runs have occurred on main in the last 7 days
-decay_lambda: 0.05
+confidence:
+  decay_lambda: 0.05
 annotations: []

--- a/rave/claims/claim-code-coverage-001.yaml
+++ b/rave/claims/claim-code-coverage-001.yaml
@@ -1,3 +1,4 @@
+rave_version: "0.2.0"
 claim_id: claim-code-coverage-001
 statement: Extension model unit test coverage meets or exceeds 70%
 owner:
@@ -14,5 +15,6 @@ assumptions:
   - 70% threshold is appropriate for an early-stage project with pure-function tests
 falsification_signals:
   - deno test exits with a non-zero exit code (tests fail, coverage cannot be measured)
-decay_lambda: 0.03
+confidence:
+  decay_lambda: 0.03
 annotations: []

--- a/rave/claims/claim-deno-lock-committed-001.yaml
+++ b/rave/claims/claim-deno-lock-committed-001.yaml
@@ -1,3 +1,4 @@
+rave_version: "0.2.0"
 claim_id: claim-deno-lock-committed-001
 statement: deno.lock is committed and matches the current import configuration
 owner:
@@ -16,5 +17,6 @@ falsification_signals:
   - deno.lock is absent from the repo root
   - deno cache --frozen exits non-zero indicating the lock file is stale
   - deno.lock appears in .gitignore
-decay_lambda: 0.05
+confidence:
+  decay_lambda: 0.05
 annotations: []

--- a/rave/claims/claim-extensions-compile-001.yaml
+++ b/rave/claims/claim-extensions-compile-001.yaml
@@ -1,3 +1,4 @@
+rave_version: "0.2.0"
 claim_id: claim-extensions-compile-001
 statement: All extension model TypeScript files in extensions/models/ compile without errors
 owner:
@@ -15,5 +16,6 @@ assumptions:
 falsification_signals:
   - tsc --noEmit exits with a non-zero exit code
   - Any extension model file produces a TypeScript type error
-decay_lambda: 0.05
+confidence:
+  decay_lambda: 0.05
 annotations: []

--- a/rave/claims/claim-lint-clean-001.yaml
+++ b/rave/claims/claim-lint-clean-001.yaml
@@ -1,3 +1,4 @@
+rave_version: "0.2.0"
 claim_id: claim-lint-clean-001
 statement: All extension model TypeScript files pass deno lint without errors
 owner:
@@ -15,5 +16,6 @@ assumptions:
 falsification_signals:
   - deno lint exits with a non-zero exit code
   - Any extension model file produces a lint error
-decay_lambda: 0.05
+confidence:
+  decay_lambda: 0.05
 annotations: []

--- a/rave/claims/claim-main-commits-via-pr-001.yaml
+++ b/rave/claims/claim-main-commits-via-pr-001.yaml
@@ -1,3 +1,4 @@
+rave_version: "0.2.0"
 claim_id: claim-main-commits-via-pr-001
 statement: Every commit on main arrived via a merged pull request — no direct pushes
 owner:
@@ -15,5 +16,6 @@ assumptions:
 falsification_signals:
   - A commit SHA on main does not appear as the merge_commit_sha of any known merged PR
   - A direct push bypasses branch protection via admin override
-decay_lambda: 0.02
+confidence:
+  decay_lambda: 0.02
 annotations: []

--- a/rave/claims/claim-merged-prs-reviewed-001.yaml
+++ b/rave/claims/claim-merged-prs-reviewed-001.yaml
@@ -1,3 +1,4 @@
+rave_version: "0.2.0"
 claim_id: claim-merged-prs-reviewed-001
 statement: Every PR merged to main in the last 30 days had at least one approving review before merge
 owner:
@@ -15,5 +16,6 @@ assumptions:
 falsification_signals:
   - Any merged PR in the last 30 days has zero APPROVED reviews
   - A merge commit appears on main from a PR with only COMMENTED or CHANGES_REQUESTED reviews
-decay_lambda: 0.03
+confidence:
+  decay_lambda: 0.03
 annotations: []

--- a/rave/claims/claim-no-known-cves-001.yaml
+++ b/rave/claims/claim-no-known-cves-001.yaml
@@ -1,3 +1,4 @@
+rave_version: "0.2.0"
 claim_id: claim-no-known-cves-001
 statement: No HIGH or CRITICAL CVEs exist in extension model npm dependencies
 owner:
@@ -15,5 +16,6 @@ assumptions:
 falsification_signals:
   - osv-scanner reports a HIGH or CRITICAL finding against any locked package
   - deno.lock is removed, making scanning impossible
-decay_lambda: 0.05
+confidence:
+  decay_lambda: 0.05
 annotations: []

--- a/rave/claims/claim-no-secrets-committed-001.yaml
+++ b/rave/claims/claim-no-secrets-committed-001.yaml
@@ -1,3 +1,4 @@
+rave_version: "0.2.0"
 claim_id: claim-no-secrets-committed-001
 statement: No secrets or credentials are committed to the repository
 owner:
@@ -15,5 +16,6 @@ assumptions:
 falsification_signals:
   - gitleaks exits with a non-zero code indicating a pattern match in any committed file
   - A new secret-like token appears in any committed file
-decay_lambda: 0.05
+confidence:
+  decay_lambda: 0.05
 annotations: []

--- a/rave/claims/claim-no-stale-untriaged-issues-001.yaml
+++ b/rave/claims/claim-no-stale-untriaged-issues-001.yaml
@@ -1,3 +1,4 @@
+rave_version: "0.2.0"
 claim_id: claim-no-stale-untriaged-issues-001
 statement: No open issue is older than 30 days without at least one label
 owner:
@@ -15,5 +16,6 @@ assumptions:
 falsification_signals:
   - Any open issue older than 30 days has no labels attached
   - A burst of unlabelled issues remains unreviewed after the 30-day window
-decay_lambda: 0.10
+confidence:
+  decay_lambda: 0.10
 annotations: []

--- a/rave/claims/claim-npm-imports-pinned-001.yaml
+++ b/rave/claims/claim-npm-imports-pinned-001.yaml
@@ -1,3 +1,4 @@
+rave_version: "0.2.0"
 claim_id: claim-npm-imports-pinned-001
 statement: "Every npm: import specifier in extensions/models/ includes an explicit @version"
 owner:
@@ -15,5 +16,6 @@ assumptions:
 falsification_signals:
   - Any npm: import in extensions/models/*.ts lacks an @version suffix
   - A new extension model is added with an unpinned npm: specifier
-decay_lambda: 0.05
+confidence:
+  decay_lambda: 0.05
 annotations: []

--- a/rave/claims/claim-rave-spec-untampered-001.yaml
+++ b/rave/claims/claim-rave-spec-untampered-001.yaml
@@ -1,3 +1,4 @@
+rave_version: "0.2.0"
 claim_id: claim-rave-spec-untampered-001
 statement: No PR mixes rave spec changes with application code changes
 owner:
@@ -13,4 +14,5 @@ assumptions:
   - git diff origin/main...HEAD accurately reflects the files changed in a PR
 falsification_signals:
   - A PR contains changes to both rave spec files and application code files
-decay_lambda: 0.05
+confidence:
+  decay_lambda: 0.05

--- a/rave/claims/claim-swamp-models-valid-001.yaml
+++ b/rave/claims/claim-swamp-models-valid-001.yaml
@@ -1,3 +1,4 @@
+rave_version: "0.2.0"
 claim_id: claim-swamp-models-valid-001
 statement: All swamp extension models in extensions/models/ pass schema and argument validation
 owner:
@@ -16,5 +17,6 @@ falsification_signals:
   - "swamp model validate --json returns passed: false for any model"
   - Any model fails definition schema validation
   - Any model method arguments schema is invalid
-decay_lambda: 0.05
+confidence:
+  decay_lambda: 0.05
 annotations: []

--- a/rave/claims/claim-swamp-workflows-valid-001.yaml
+++ b/rave/claims/claim-swamp-workflows-valid-001.yaml
@@ -1,3 +1,4 @@
+rave_version: "0.2.0"
 claim_id: claim-swamp-workflows-valid-001
 statement: All swamp workflow YAML files in workflows/ pass schema validation
 owner:
@@ -15,5 +16,6 @@ falsification_signals:
   - "swamp workflow validate --json returns passed: false for any workflow"
   - Any workflow fails schema validation
   - Any workflow references a model or step that does not exist
-decay_lambda: 0.05
+confidence:
+  decay_lambda: 0.05
 annotations: []

--- a/rave/claims/claim-unit-tests-pass-001.yaml
+++ b/rave/claims/claim-unit-tests-pass-001.yaml
@@ -1,3 +1,4 @@
+rave_version: "0.2.0"
 claim_id: claim-unit-tests-pass-001
 statement: All unit tests for extension models pass on main
 owner:
@@ -15,5 +16,6 @@ assumptions:
 falsification_signals:
   - deno test exits with a non-zero exit code
   - Any test assertion fails
-decay_lambda: 0.05
+confidence:
+  decay_lambda: 0.05
 annotations: []

--- a/rave/config.yaml
+++ b/rave/config.yaml
@@ -9,5 +9,6 @@
 #
 # Downstream repos that adopt rave-swamp should omit this file entirely
 # (or keep enabled: true) to get the full protection.
+rave_version: "0.2.0"
 tamper_guard:
   enabled: false

--- a/rave/scopes/rave-swamp.yaml
+++ b/rave/scopes/rave-swamp.yaml
@@ -1,4 +1,4 @@
-version: "0.1.0"
+rave_version: "0.2.0"
 description: "Scope hierarchy for the rave-swamp repository"
 scopes:
   - type: "repository"


### PR DESCRIPTION
Closes #77

## Summary

- Adds `rave_version: "0.2.0"` preamble to all 16 claim files, `rave/scopes/rave-swamp.yaml`, and `rave/config.yaml`
- Moves top-level `decay_lambda` into a nested `confidence.decay_lambda` block on all 16 claim files (v0.2 §6.2 confidence block shape)
- Updates `bin/lib/claims.ts` to read `confidence.decay_lambda` with backward-compat fallback to v0.1 top-level `decay_lambda`

No semantic changes: all claims remain Claims; no decomposition into Facts/Validations/Capabilities. `falsification_signals` and `owner` stay inline (v0.2 spec allows inline shorthand).

Prerequisite for Issue B (extension model schema update) and #32 (v0.2 readiness reporter).

## Test plan

- [x] All 16 claim files have `rave_version: "0.2.0"` as first field and `confidence.decay_lambda` (not top-level `decay_lambda`)
- [x] `rave/scopes/rave-swamp.yaml` has `rave_version: "0.2.0"`
- [x] `bin/lib/claims.ts` reads nested `confidence.decay_lambda` with v0.1 fallback
- [ ] `deno task check` — requires live Swamp instance; gate behavior is unchanged since `decay_lambda` is not used in confidence scoring (scores come from `swamp data get`, not from claim YAML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)