### PR TITLE
Update rave_claim.ts to write v0.2 claim schema on create

### DIFF
--- a/extensions/models/rave_claim.ts
+++ b/extensions/models/rave_claim.ts
@@ -94,13 +94,14 @@ export const model = {
         if (args.contact) owner.contact = args.contact;
 
         const claim: Record<string, unknown> = {
+          rave_version: "0.2.0",
           claim_id: claimId,
           statement: args.statement,
           owner,
           status: "draft",
           category: args.category,
           scope: { type: args.scopeType, target: args.scopeTarget },
-          decay_lambda: args.decayLambda,
+          confidence: { decay_lambda: args.decayLambda },
           assumptions: args.assumptions,
           falsification_signals: args.falsificationSignals,
           annotations: [],


### PR DESCRIPTION
Closes #79

## Summary

Single-method fix in `rave_claim.ts`: the `create` method now writes new claim files in RAVE v0.2 format:
- Adds `rave_version: "0.2.0"` as the first field
- Moves `decay_lambda` from top-level into `confidence: { decay_lambda: ... }`

No read-path changes needed — `get`, `activate`, `retire`, `contradict`, and `annotate` only access `status`, `statement`, `category`, and `annotations`, none of which moved in v0.2.

Prerequisite for #32 (v0.2 scope-aware readiness reporter).

## Test plan

- [x] `deno fmt --check extensions/models/` — clean
- [x] `deno lint extensions/models/` — clean
- [x] `deno check extensions/models/*.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)