### PR TITLE
Scope-aware v0.2 readiness reporter (#32)

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -4,9 +4,11 @@
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/assert@1.0.19": "1.0.19",
     "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/path@1": "1.1.4",
     "jsr:@std/yaml@1": "1.0.12",
     "jsr:@systeminit/swamp-testing@~0.20260424.9": "0.20260424.9",
-    "npm:yaml@2": "2.8.3",
+    "npm:yaml@2": "2.7.0",
+    "npm:yaml@2.7.0": "2.7.0",
     "npm:zod@4": "4.3.6",
     "npm:zod@^4.3.6": "4.3.6"
   },
@@ -20,6 +22,12 @@
     "@std/internal@1.0.12": {
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     },
+    "@std/path@1.1.4": {
+      "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
     "@std/yaml@1.0.12": {
       "integrity": "7deabca4545bcedd07c5f69ea53acea71b8b4c67562f224e17b90d75944cb20c"
     },
@@ -32,8 +40,8 @@
     }
   },
   "npm": {
-    "yaml@2.8.3": {
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+    "yaml@2.7.0": {
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
       "bin": true
     },
     "zod@4.3.6": {

--- a/extensions/models/rave_readiness_reporter.test.ts
+++ b/extensions/models/rave_readiness_reporter.test.ts
@@ -1,106 +1,291 @@
 import { assertEquals } from "jsr:@std/assert@1";
 
 // ---------------------------------------------------------------------------
-// Re-implement evaluateClaim (exact copy from rave_readiness_reporter.ts).
+// Re-implement evaluateNode (exact copy from rave_readiness_reporter.ts).
 // ---------------------------------------------------------------------------
 
-type ClaimReadiness = {
-  claimId: string;
-  status: string;
-  confidenceScore: number;
-  meetsThreshold: boolean;
-  reason: string | null;
+type EvaluatedNode = {
+  nodeId: string;
+  nodeType: string;
+  confidence: number;
+  aboveThreshold: boolean;
+  reason?: string;
 };
 
-function evaluateClaim(
-  claimId: string,
+type FailingNode = {
+  nodeId: string;
+  nodeType: string;
+  confidence: number;
+  threshold: number;
+  reason: string;
+  suggestedRemediation?: string;
+};
+
+function evaluateNode(
+  nodeId: string,
+  nodeType: string,
   status: string,
   confidenceScore: number,
   threshold: number,
-): ClaimReadiness {
+): { evaluated: EvaluatedNode; failing: FailingNode | null } {
   if (status === "draft" || status === "retired") {
     return {
-      claimId,
-      status,
-      confidenceScore,
-      meetsThreshold: true,
-      reason: `${status} — excluded from readiness gate`,
+      evaluated: {
+        nodeId,
+        nodeType,
+        confidence: confidenceScore,
+        aboveThreshold: true,
+        reason: `${status} — excluded from readiness gate`,
+      },
+      failing: null,
     };
   }
   if (status === "contradicted") {
+    const reason = "Contradicted — requires revision";
     return {
-      claimId,
-      status,
-      confidenceScore,
-      meetsThreshold: false,
-      reason: "contradicted — fails readiness gate",
+      evaluated: {
+        nodeId,
+        nodeType,
+        confidence: confidenceScore,
+        aboveThreshold: false,
+        reason,
+      },
+      failing: {
+        nodeId,
+        nodeType,
+        confidence: confidenceScore,
+        threshold,
+        reason,
+      },
     };
   }
-  const meetsThreshold = confidenceScore >= threshold;
+  if (status === "unknown") {
+    const reason = "Status unknown — no runtime data available";
+    return {
+      evaluated: {
+        nodeId,
+        nodeType,
+        confidence: 0,
+        aboveThreshold: false,
+        reason,
+      },
+      failing: { nodeId, nodeType, confidence: 0, threshold, reason },
+    };
+  }
+  const aboveThreshold = confidenceScore >= threshold;
+  if (aboveThreshold) {
+    return {
+      evaluated: {
+        nodeId,
+        nodeType,
+        confidence: confidenceScore,
+        aboveThreshold: true,
+      },
+      failing: null,
+    };
+  }
+  const reason = `Confidence ${
+    confidenceScore.toFixed(3)
+  } below threshold ${threshold}`;
   return {
-    claimId,
-    status,
-    confidenceScore,
-    meetsThreshold,
-    reason: meetsThreshold
-      ? null
-      : `score ${confidenceScore.toFixed(3)} below threshold ${threshold}`,
+    evaluated: {
+      nodeId,
+      nodeType,
+      confidence: confidenceScore,
+      aboveThreshold: false,
+      reason,
+    },
+    failing: {
+      nodeId,
+      nodeType,
+      confidence: confidenceScore,
+      threshold,
+      reason,
+    },
   };
 }
 
+function inScope(
+  nodeScopeType: string,
+  nodeScopeTarget: string,
+  filterType: string,
+  filterTarget: string,
+  includeDescendants: boolean,
+): boolean {
+  if (nodeScopeType === filterType && nodeScopeTarget === filterTarget) {
+    return true;
+  }
+  if (includeDescendants && nodeScopeTarget.startsWith(filterTarget + "/")) {
+    return true;
+  }
+  return false;
+}
+
 // ---------------------------------------------------------------------------
-// Tests
+// evaluateNode tests
 // ---------------------------------------------------------------------------
 
-Deno.test("evaluateClaim: active claim above threshold → passes", () => {
-  const r = evaluateClaim("claim-001", "active", 0.85, 0.7);
-  assertEquals(r.meetsThreshold, true);
-  assertEquals(r.reason, null);
+Deno.test("evaluateNode: active above threshold → passes, no reason", () => {
+  const { evaluated, failing } = evaluateNode(
+    "claim-001",
+    "claim",
+    "active",
+    0.85,
+    0.7,
+  );
+  assertEquals(evaluated.aboveThreshold, true);
+  assertEquals(evaluated.reason, undefined);
+  assertEquals(failing, null);
 });
 
-Deno.test("evaluateClaim: active claim exactly at threshold → passes", () => {
-  const r = evaluateClaim("claim-001", "active", 0.7, 0.7);
-  assertEquals(r.meetsThreshold, true);
-  assertEquals(r.reason, null);
+Deno.test("evaluateNode: active exactly at threshold → passes", () => {
+  const { evaluated, failing } = evaluateNode(
+    "claim-001",
+    "claim",
+    "active",
+    0.7,
+    0.7,
+  );
+  assertEquals(evaluated.aboveThreshold, true);
+  assertEquals(failing, null);
 });
 
-Deno.test("evaluateClaim: active claim below threshold → fails with reason", () => {
-  const r = evaluateClaim("claim-001", "active", 0.5, 0.7);
-  assertEquals(r.meetsThreshold, false);
-  assertEquals(r.reason, "score 0.500 below threshold 0.7");
+Deno.test("evaluateNode: active below threshold → fails with reason including score and threshold", () => {
+  const { evaluated, failing } = evaluateNode(
+    "claim-001",
+    "claim",
+    "active",
+    0.5,
+    0.7,
+  );
+  assertEquals(evaluated.aboveThreshold, false);
+  assertEquals(evaluated.reason, "Confidence 0.500 below threshold 0.7");
+  assertEquals(failing?.reason, "Confidence 0.500 below threshold 0.7");
+  assertEquals(failing?.threshold, 0.7);
 });
 
-Deno.test("evaluateClaim: draft claim → excluded, meetsThreshold=true", () => {
-  const r = evaluateClaim("claim-001", "draft", 0.0, 0.7);
-  assertEquals(r.meetsThreshold, true);
-  assertEquals(r.reason, "draft — excluded from readiness gate");
+Deno.test("evaluateNode: draft → excluded, aboveThreshold=true, no failing entry", () => {
+  const { evaluated, failing } = evaluateNode(
+    "claim-001",
+    "claim",
+    "draft",
+    0.0,
+    0.7,
+  );
+  assertEquals(evaluated.aboveThreshold, true);
+  assertEquals(evaluated.reason, "draft — excluded from readiness gate");
+  assertEquals(failing, null);
 });
 
-Deno.test("evaluateClaim: retired claim → excluded, meetsThreshold=true", () => {
-  const r = evaluateClaim("claim-001", "retired", 0.3, 0.7);
-  assertEquals(r.meetsThreshold, true);
-  assertEquals(r.reason, "retired — excluded from readiness gate");
+Deno.test("evaluateNode: retired → excluded, aboveThreshold=true, no failing entry", () => {
+  const { evaluated, failing } = evaluateNode(
+    "claim-001",
+    "claim",
+    "retired",
+    0.3,
+    0.7,
+  );
+  assertEquals(evaluated.aboveThreshold, true);
+  assertEquals(evaluated.reason, "retired — excluded from readiness gate");
+  assertEquals(failing, null);
 });
 
-Deno.test("evaluateClaim: contradicted claim → always fails regardless of score", () => {
-  const r = evaluateClaim("claim-001", "contradicted", 0.99, 0.7);
-  assertEquals(r.meetsThreshold, false);
-  assertEquals(r.reason, "contradicted — fails readiness gate");
+Deno.test("evaluateNode: contradicted → always fails regardless of score", () => {
+  const { evaluated, failing } = evaluateNode(
+    "claim-001",
+    "claim",
+    "contradicted",
+    0.99,
+    0.7,
+  );
+  assertEquals(evaluated.aboveThreshold, false);
+  assertEquals(failing?.reason, "Contradicted — requires revision");
 });
 
-Deno.test("evaluateClaim: zero score for active claim → fails", () => {
-  const r = evaluateClaim("claim-001", "active", 0.0, 0.7);
-  assertEquals(r.meetsThreshold, false);
+Deno.test("evaluateNode: unknown status → fails, confidence set to 0", () => {
+  const { evaluated, failing } = evaluateNode(
+    "claim-001",
+    "claim",
+    "unknown",
+    0.0,
+    0.7,
+  );
+  assertEquals(evaluated.aboveThreshold, false);
+  assertEquals(evaluated.confidence, 0);
+  assertEquals(failing?.reason, "Status unknown — no runtime data available");
 });
 
-Deno.test("evaluateClaim: threshold 0 → any active score passes", () => {
-  const r = evaluateClaim("claim-001", "active", 0.0, 0.0);
-  assertEquals(r.meetsThreshold, true);
+Deno.test("evaluateNode: non-claim nodeType flows through unchanged", () => {
+  const { evaluated } = evaluateNode("fact-001", "fact", "active", 0.9, 0.7);
+  assertEquals(evaluated.nodeType, "fact");
+  assertEquals(evaluated.aboveThreshold, true);
 });
 
-Deno.test("evaluateClaim: claimId and status are preserved in output", () => {
-  const r = evaluateClaim("claim-my-test-001", "active", 0.8, 0.7);
-  assertEquals(r.claimId, "claim-my-test-001");
-  assertEquals(r.status, "active");
-  assertEquals(r.confidenceScore, 0.8);
+Deno.test("evaluateNode: threshold 0 → any active score passes", () => {
+  const { evaluated } = evaluateNode("claim-001", "claim", "active", 0.0, 0.0);
+  assertEquals(evaluated.aboveThreshold, true);
+});
+
+// ---------------------------------------------------------------------------
+// inScope tests
+// ---------------------------------------------------------------------------
+
+Deno.test("inScope: exact match on type and target → true", () => {
+  assertEquals(
+    inScope("pipeline", "org/repo/main", "pipeline", "org/repo/main", false),
+    true,
+  );
+});
+
+Deno.test("inScope: descendant target with includeDescendants=true → true", () => {
+  assertEquals(
+    inScope("pipeline", "org/repo/main", "repository", "org/repo", true),
+    true,
+  );
+});
+
+Deno.test("inScope: descendant target with includeDescendants=false → false", () => {
+  assertEquals(
+    inScope("pipeline", "org/repo/main", "repository", "org/repo", false),
+    false,
+  );
+});
+
+Deno.test("inScope: unrelated target → false", () => {
+  assertEquals(
+    inScope("pipeline", "org/other/main", "repository", "org/repo", true),
+    false,
+  );
+});
+
+Deno.test("inScope: partial prefix without slash separator → false (no false prefix match)", () => {
+  // "org/repo-extra" should NOT match scope target "org/repo"
+  assertEquals(
+    inScope("component", "org/repo-extra/x", "repository", "org/repo", true),
+    false,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Output shape test (v0.2 field names)
+// ---------------------------------------------------------------------------
+
+Deno.test("v0.2 assessment shape: evaluated and failing node fields are present", () => {
+  const { evaluated, failing } = evaluateNode(
+    "claim-branch-protection-001",
+    "claim",
+    "active",
+    0.5,
+    0.7,
+  );
+  // evaluatedNodes shape
+  assertEquals(typeof evaluated.nodeId, "string");
+  assertEquals(typeof evaluated.nodeType, "string");
+  assertEquals(typeof evaluated.confidence, "number");
+  assertEquals(typeof evaluated.aboveThreshold, "boolean");
+  // failingNodes shape
+  assertEquals(typeof failing?.nodeId, "string");
+  assertEquals(typeof failing?.confidence, "number");
+  assertEquals(typeof failing?.threshold, "number");
+  assertEquals(typeof failing?.reason, "string");
 });

--- a/extensions/models/rave_readiness_reporter.ts
+++ b/extensions/models/rave_readiness_reporter.ts
@@ -1,82 +1,247 @@
 import { z } from "npm:zod@4";
+import { parse as parseYaml } from "npm:yaml@2.7.0";
+import { join } from "jsr:@std/path@1";
 
 // ---------------------------------------------------------------------------
 // Schemas
 // ---------------------------------------------------------------------------
 
+const NodeEntrySchema = z.object({
+  nodeId: z.string(),
+  nodeType: z.enum(["fact", "claim", "validation", "capability"]),
+  status: z.string().default("active"),
+  confidenceScore: z.coerce.number(),
+});
+
 const EvaluateArgsSchema = z.object({
+  scopeType: z.string().default("repository"),
+  scopeTarget: z.string().default("mesgme/rave-swamp"),
   threshold: z.coerce.number().min(0).max(1).default(0.7),
-  // Per-claim inputs — flat args because CEL cannot construct arrays in workflow inputs
-  branchProtectionId: z.string(),
-  branchProtectionStatus: z.string(),
-  branchProtectionScore: z.coerce.number(),
-  ciGreenId: z.string(),
-  ciGreenStatus: z.string(),
-  ciGreenScore: z.coerce.number(),
-  swampModelsId: z.string(),
-  swampModelsStatus: z.string(),
-  swampModelsScore: z.coerce.number(),
-  swampWorkflowsId: z.string(),
-  swampWorkflowsStatus: z.string(),
-  swampWorkflowsScore: z.coerce.number(),
-  extensionsCompileId: z.string(),
-  extensionsCompileStatus: z.string(),
-  extensionsCompileScore: z.coerce.number(),
+  includeDescendants: z.coerce.boolean().default(true),
+  nodes: z.array(NodeEntrySchema),
 });
 
-const ClaimReadinessSchema = z.object({
-  claimId: z.string(),
-  status: z.string(),
-  confidenceScore: z.number(),
-  meetsThreshold: z.boolean(),
-  reason: z.string().nullable(),
+const EvaluatedNodeSchema = z.object({
+  nodeId: z.string(),
+  nodeType: z.string(),
+  confidence: z.number(),
+  aboveThreshold: z.boolean(),
+  reason: z.string().optional(),
 });
 
-const ReportSchema = z.object({
+const FailingNodeSchema = z.object({
+  nodeId: z.string(),
+  nodeType: z.string(),
+  confidence: z.number(),
   threshold: z.number(),
-  ready: z.boolean(),
+  reason: z.string(),
+  suggestedRemediation: z.string().optional(),
+});
+
+const AssessmentSchema = z.object({
+  raveVersion: z.literal("0.2.0"),
+  scope: z.object({ type: z.string(), target: z.string() }),
+  threshold: z.number(),
   evaluatedAt: z.string(),
-  claims: z.array(ClaimReadinessSchema),
+  ready: z.boolean(),
   summary: z.string(),
+  includeDescendants: z.boolean(),
+  evaluatedNodes: z.array(EvaluatedNodeSchema),
+  failingNodes: z.array(FailingNodeSchema),
+  propagationTrace: z.array(
+    z.object({
+      sourceId: z.string(),
+      propagatedTo: z.string(),
+      edgeType: z.string(),
+      impact: z.string(),
+    }),
+  ).default([]),
 });
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function evaluateClaim(
-  claimId: string,
+interface RawNodeFile {
+  claim_id?: string;
+  fact_id?: string;
+  validation_id?: string;
+  capability_id?: string;
+  scope?: { type?: string; target?: string };
+  status?: string;
+}
+
+function nodeIdFromRaw(raw: RawNodeFile): string | undefined {
+  return (
+    raw.claim_id ??
+      raw.fact_id ??
+      raw.validation_id ??
+      raw.capability_id
+  );
+}
+
+function nodeTypeFromSubdir(
+  subdir: string,
+): z.infer<typeof NodeEntrySchema>["nodeType"] {
+  const map: Record<string, z.infer<typeof NodeEntrySchema>["nodeType"]> = {
+    claims: "claim",
+    facts: "fact",
+    validations: "validation",
+    capabilities: "capability",
+  };
+  return map[subdir] ?? "claim";
+}
+
+async function loadNodesFromDisk(
+  repoDir: string,
+): Promise<
+  Array<
+    {
+      nodeId: string;
+      nodeType: z.infer<typeof NodeEntrySchema>["nodeType"];
+      scopeType: string;
+      scopeTarget: string;
+    }
+  >
+> {
+  const subdirs = ["claims", "facts", "validations", "capabilities"];
+  const result: Array<
+    {
+      nodeId: string;
+      nodeType: z.infer<typeof NodeEntrySchema>["nodeType"];
+      scopeType: string;
+      scopeTarget: string;
+    }
+  > = [];
+
+  for (const subdir of subdirs) {
+    const dir = join(repoDir, "rave", subdir);
+    let entries: Deno.DirEntry[];
+    try {
+      entries = [];
+      for await (const e of Deno.readDir(dir)) {
+        if (e.isFile && e.name.endsWith(".yaml")) entries.push(e);
+      }
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const text = await Deno.readTextFile(join(dir, entry.name));
+      const raw = parseYaml(text) as RawNodeFile;
+      const nodeId = nodeIdFromRaw(raw);
+      if (!nodeId) continue;
+      result.push({
+        nodeId,
+        nodeType: nodeTypeFromSubdir(subdir),
+        scopeType: raw.scope?.type ?? "",
+        scopeTarget: raw.scope?.target ?? "",
+      });
+    }
+  }
+  return result;
+}
+
+function inScope(
+  nodeScopeType: string,
+  nodeScopeTarget: string,
+  filterType: string,
+  filterTarget: string,
+  includeDescendants: boolean,
+): boolean {
+  if (nodeScopeType === filterType && nodeScopeTarget === filterTarget) {
+    return true;
+  }
+  if (includeDescendants && nodeScopeTarget.startsWith(filterTarget + "/")) {
+    return true;
+  }
+  return false;
+}
+
+function evaluateNode(
+  nodeId: string,
+  nodeType: string,
   status: string,
   confidenceScore: number,
   threshold: number,
-): z.infer<typeof ClaimReadinessSchema> {
+): {
+  evaluated: z.infer<typeof EvaluatedNodeSchema>;
+  failing: z.infer<typeof FailingNodeSchema> | null;
+} {
   if (status === "draft" || status === "retired") {
     return {
-      claimId,
-      status,
-      confidenceScore,
-      meetsThreshold: true,
-      reason: `${status} — excluded from readiness gate`,
+      evaluated: {
+        nodeId,
+        nodeType,
+        confidence: confidenceScore,
+        aboveThreshold: true,
+        reason: `${status} — excluded from readiness gate`,
+      },
+      failing: null,
     };
   }
   if (status === "contradicted") {
+    const reason = "Contradicted — requires revision";
     return {
-      claimId,
-      status,
-      confidenceScore,
-      meetsThreshold: false,
-      reason: "contradicted — fails readiness gate",
+      evaluated: {
+        nodeId,
+        nodeType,
+        confidence: confidenceScore,
+        aboveThreshold: false,
+        reason,
+      },
+      failing: {
+        nodeId,
+        nodeType,
+        confidence: confidenceScore,
+        threshold,
+        reason,
+      },
     };
   }
-  const meetsThreshold = confidenceScore >= threshold;
+  if (status === "unknown") {
+    const reason = "Status unknown — no runtime data available";
+    return {
+      evaluated: {
+        nodeId,
+        nodeType,
+        confidence: 0,
+        aboveThreshold: false,
+        reason,
+      },
+      failing: { nodeId, nodeType, confidence: 0, threshold, reason },
+    };
+  }
+  // active (or any unrecognised status treated as active)
+  const aboveThreshold = confidenceScore >= threshold;
+  if (aboveThreshold) {
+    return {
+      evaluated: {
+        nodeId,
+        nodeType,
+        confidence: confidenceScore,
+        aboveThreshold: true,
+      },
+      failing: null,
+    };
+  }
+  const reason = `Confidence ${
+    confidenceScore.toFixed(3)
+  } below threshold ${threshold}`;
   return {
-    claimId,
-    status,
-    confidenceScore,
-    meetsThreshold,
-    reason: meetsThreshold
-      ? null
-      : `score ${confidenceScore.toFixed(3)} below threshold ${threshold}`,
+    evaluated: {
+      nodeId,
+      nodeType,
+      confidence: confidenceScore,
+      aboveThreshold: false,
+      reason,
+    },
+    failing: {
+      nodeId,
+      nodeType,
+      confidence: confidenceScore,
+      threshold,
+      reason,
+    },
   };
 }
 
@@ -86,11 +251,11 @@ function evaluateClaim(
 
 export const model = {
   type: "@mellens/rave/readiness-reporter",
-  version: "2026.03.23.1",
+  version: "2026.05.07.1",
   resources: {
     report: {
-      description: "Latest readiness evaluation report",
-      schema: ReportSchema,
+      description: "Latest v0.2 readiness assessment",
+      schema: AssessmentSchema,
       lifetime: "7d",
       garbageCollection: 50,
     },
@@ -98,78 +263,112 @@ export const model = {
   methods: {
     evaluate: {
       description:
-        "Evaluate readiness across all active claims by comparing confidence scores to threshold. Draft and retired claims are excluded; contradicted claims always fail.",
+        "Evaluate readiness for a scope by comparing confidence scores to threshold. Reads all node YAML files from disk to discover in-scope nodes; cross-references with the nodes input for runtime status and scores. Emits a v0.2 readiness assessment.",
       arguments: EvaluateArgsSchema,
-      execute: async (args, context) => {
+      execute: async (args: z.infer<typeof EvaluateArgsSchema>, context: {
+        repoDir: string;
+        logger: { info: (m: string) => void; warn: (m: string) => void };
+        writeResource: (
+          resource: string,
+          slot: string,
+          data: unknown,
+        ) => Promise<unknown>;
+      }) => {
         const evaluatedAt = new Date().toISOString();
-        const threshold = args.threshold;
+        const { scopeType, scopeTarget, threshold, includeDescendants, nodes } =
+          args;
 
-        const claims = [
-          evaluateClaim(
-            args.branchProtectionId,
-            args.branchProtectionStatus,
-            args.branchProtectionScore,
-            threshold,
-          ),
-          evaluateClaim(
-            args.ciGreenId,
-            args.ciGreenStatus,
-            args.ciGreenScore,
-            threshold,
-          ),
-          evaluateClaim(
-            args.swampModelsId,
-            args.swampModelsStatus,
-            args.swampModelsScore,
-            threshold,
-          ),
-          evaluateClaim(
-            args.swampWorkflowsId,
-            args.swampWorkflowsStatus,
-            args.swampWorkflowsScore,
-            threshold,
-          ),
-          evaluateClaim(
-            args.extensionsCompileId,
-            args.extensionsCompileStatus,
-            args.extensionsCompileScore,
-            threshold,
-          ),
-        ];
+        // Build lookup map from input nodes array
+        const nodeMap = new Map(nodes.map((n) => [n.nodeId, n]));
 
-        const gateClaims = claims.filter(
-          (c) => c.status !== "draft" && c.status !== "retired",
+        // Discover all nodes from disk, filter by scope
+        const diskNodes = await loadNodesFromDisk(context.repoDir);
+        const scopedNodes = diskNodes.filter((n) =>
+          inScope(
+            n.scopeType,
+            n.scopeTarget,
+            scopeType,
+            scopeTarget,
+            includeDescendants,
+          )
         );
-        const ready = gateClaims.length > 0
-          ? gateClaims.every((c) => c.meetsThreshold)
-          : true;
 
-        const passing = gateClaims.filter((c) => c.meetsThreshold).length;
-        const excluded = claims.length - gateClaims.length;
+        const evaluatedNodes: z.infer<typeof EvaluatedNodeSchema>[] = [];
+        const failingNodes: z.infer<typeof FailingNodeSchema>[] = [];
+
+        for (const diskNode of scopedNodes) {
+          const runtime = nodeMap.get(diskNode.nodeId);
+          if (!runtime) {
+            context.logger.warn(
+              `Node ${diskNode.nodeId} in scope but missing from nodes input — treating as unknown/failing`,
+            );
+            const { evaluated, failing } = evaluateNode(
+              diskNode.nodeId,
+              diskNode.nodeType,
+              "unknown",
+              0,
+              threshold,
+            );
+            evaluatedNodes.push(evaluated);
+            if (failing) failingNodes.push(failing);
+            continue;
+          }
+          const { evaluated, failing } = evaluateNode(
+            runtime.nodeId,
+            runtime.nodeType,
+            runtime.status,
+            runtime.confidenceScore,
+            threshold,
+          );
+          evaluatedNodes.push(evaluated);
+          if (failing) failingNodes.push(failing);
+        }
+
+        const activeNodes = evaluatedNodes.filter(
+          (n) =>
+            n.reason !== `draft — excluded from readiness gate` &&
+            n.reason !== `retired — excluded from readiness gate`,
+        );
+        const ready = failingNodes.length === 0;
+
+        const passing = activeNodes.filter((n) => n.aboveThreshold).length;
+        const excluded = evaluatedNodes.length - activeNodes.length;
         const summary = [
-          `${passing} of ${gateClaims.length} active claims meet threshold (${threshold}).`,
-          excluded > 0 ? `${excluded} claim(s) excluded (draft/retired).` : "",
-        ]
-          .filter(Boolean)
-          .join(" ");
+          `${passing} of ${activeNodes.length} active nodes meet threshold (${threshold}).`,
+          excluded > 0 ? `${excluded} node(s) excluded (draft/retired).` : "",
+        ].filter(Boolean).join(" ");
 
         if (ready) {
-          context.logger.info(`Readiness: READY — ${summary}`);
+          context.logger.info(
+            `Readiness [${scopeType}/${scopeTarget}]: READY — ${summary}`,
+          );
         } else {
-          context.logger.warn(`Readiness: NOT READY — ${summary}`);
-          for (const c of gateClaims.filter((x) => !x.meetsThreshold)) {
-            context.logger.warn(`  ✗ ${c.claimId}: ${c.reason}`);
+          context.logger.warn(
+            `Readiness [${scopeType}/${scopeTarget}]: NOT READY — ${summary}`,
+          );
+          for (const f of failingNodes) {
+            context.logger.warn(`  ✗ ${f.nodeId}: ${f.reason}`);
           }
         }
 
-        const handle = await context.writeResource("report", "current", {
+        const assessment: z.infer<typeof AssessmentSchema> = {
+          raveVersion: "0.2.0",
+          scope: { type: scopeType, target: scopeTarget },
           threshold,
-          ready,
           evaluatedAt,
-          claims,
+          ready,
           summary,
-        });
+          includeDescendants,
+          evaluatedNodes,
+          failingNodes,
+          propagationTrace: [],
+        };
 
+        const handle = await context.writeResource(
+          "report",
+          "current",
+          assessment,
+        );
         return { dataHandles: [handle] };
       },
     },

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,6 @@
 manifestVersion: 1
 name: "@mellens/rave"
-version: "2026.04.30.1"
+version: "2026.05.07.1"
 description: "RAVE (Reliability & Validation Engineering) — confidence scoring with exponential decay, claim lifecycle management, evidence gathering from GitHub and Prometheus, falsification detection, and readiness gating for software reliability claims"
 models:
   - rave_claim.ts

--- a/workflows/workflow-adfc9a4a-a667-4f4f-8f98-7d9edee3893d.yaml
+++ b/workflows/workflow-adfc9a4a-a667-4f4f-8f98-7d9edee3893d.yaml
@@ -1,10 +1,22 @@
 id: adfc9a4a-a667-4f4f-8f98-7d9edee3893d
 name: readiness-check
-description: On-demand readiness evaluation. Reads latest confidence scores for all active claims and determines if they meet the threshold. Exits successfully regardless of result — output is informative.
+description: On-demand readiness evaluation. Reads all in-scope node YAML files from the repo, cross-references with live confidence scores, and produces a v0.2 readiness assessment. Exits successfully regardless of result — output is informative.
 tags: {}
-version: 1
+version: 2
 inputs:
   properties:
+    scopeType:
+      type: string
+      default: "repository"
+      description: Scope type to evaluate (repository, pipeline, component)
+    scopeTarget:
+      type: string
+      default: "mesgme/rave-swamp"
+      description: Scope target to evaluate
+    includeDescendants:
+      type: boolean
+      default: true
+      description: Whether to include nodes whose scope is a descendant of scopeTarget
     threshold:
       type: number
       default: 0.7
@@ -12,31 +24,84 @@ inputs:
   required: []
 jobs:
   - name: evaluate
-    description: Read confidence scores and evaluate readiness against threshold
+    description: Evaluate readiness for the requested scope using v0.2 assessment shape
     dependsOn: []
     weight: 0
     steps:
       - name: report
-        description: Produce readiness report from latest confidence data
+        description: Produce v0.2 readiness assessment from live confidence data
         allowFailure: false
         task:
           type: model_method
           modelIdOrName: readiness-reporter-001
           methodName: evaluate
           inputs:
+            scopeType: ${{ inputs.scopeType }}
+            scopeTarget: ${{ inputs.scopeTarget }}
+            includeDescendants: ${{ inputs.includeDescendants }}
             threshold: ${{ inputs.threshold }}
-            branchProtectionId: "claim-branch-protection-001"
-            branchProtectionStatus: "active"
-            branchProtectionScore: ${{ data.latest("confidence-claim-branch-protection-001", "current").attributes.confidenceScore }}
-            ciGreenId: "claim-ci-green-on-main-001"
-            ciGreenStatus: "active"
-            ciGreenScore: ${{ data.latest("confidence-claim-ci-green-on-main-001", "current").attributes.confidenceScore }}
-            swampModelsId: "claim-swamp-models-valid-001"
-            swampModelsStatus: "active"
-            swampModelsScore: ${{ data.latest("confidence-claim-swamp-models-valid-001", "current").attributes.confidenceScore }}
-            swampWorkflowsId: "claim-swamp-workflows-valid-001"
-            swampWorkflowsStatus: "active"
-            swampWorkflowsScore: ${{ data.latest("confidence-claim-swamp-workflows-valid-001", "current").attributes.confidenceScore }}
-            extensionsCompileId: "claim-extensions-compile-001"
-            extensionsCompileStatus: "active"
-            extensionsCompileScore: ${{ data.latest("confidence-claim-extensions-compile-001", "current").attributes.confidenceScore }}
+            nodes:
+              - nodeId: "claim-branch-protection-001"
+                nodeType: "claim"
+                status: "active"
+                confidenceScore: ${{ data.latest("confidence-claim-branch-protection-001", "current").attributes.confidenceScore }}
+              - nodeId: "claim-ci-green-on-main-001"
+                nodeType: "claim"
+                status: "active"
+                confidenceScore: ${{ data.latest("confidence-claim-ci-green-on-main-001", "current").attributes.confidenceScore }}
+              - nodeId: "claim-code-coverage-001"
+                nodeType: "claim"
+                status: "active"
+                confidenceScore: ${{ data.latest("confidence-claim-code-coverage-001", "current").attributes.confidenceScore }}
+              - nodeId: "claim-deno-lock-committed-001"
+                nodeType: "claim"
+                status: "active"
+                confidenceScore: ${{ data.latest("confidence-claim-deno-lock-committed-001", "current").attributes.confidenceScore }}
+              - nodeId: "claim-extensions-compile-001"
+                nodeType: "claim"
+                status: "active"
+                confidenceScore: ${{ data.latest("confidence-claim-extensions-compile-001", "current").attributes.confidenceScore }}
+              - nodeId: "claim-lint-clean-001"
+                nodeType: "claim"
+                status: "active"
+                confidenceScore: ${{ data.latest("confidence-claim-lint-clean-001", "current").attributes.confidenceScore }}
+              - nodeId: "claim-main-commits-via-pr-001"
+                nodeType: "claim"
+                status: "active"
+                confidenceScore: ${{ data.latest("confidence-claim-main-commits-via-pr-001", "current").attributes.confidenceScore }}
+              - nodeId: "claim-merged-prs-reviewed-001"
+                nodeType: "claim"
+                status: "active"
+                confidenceScore: ${{ data.latest("confidence-claim-merged-prs-reviewed-001", "current").attributes.confidenceScore }}
+              - nodeId: "claim-no-known-cves-001"
+                nodeType: "claim"
+                status: "active"
+                confidenceScore: ${{ data.latest("confidence-claim-no-known-cves-001", "current").attributes.confidenceScore }}
+              - nodeId: "claim-no-secrets-committed-001"
+                nodeType: "claim"
+                status: "active"
+                confidenceScore: ${{ data.latest("confidence-claim-no-secrets-committed-001", "current").attributes.confidenceScore }}
+              - nodeId: "claim-no-stale-untriaged-issues-001"
+                nodeType: "claim"
+                status: "active"
+                confidenceScore: ${{ data.latest("confidence-claim-no-stale-untriaged-issues-001", "current").attributes.confidenceScore }}
+              - nodeId: "claim-npm-imports-pinned-001"
+                nodeType: "claim"
+                status: "active"
+                confidenceScore: ${{ data.latest("confidence-claim-npm-imports-pinned-001", "current").attributes.confidenceScore }}
+              - nodeId: "claim-rave-spec-untampered-001"
+                nodeType: "claim"
+                status: "active"
+                confidenceScore: ${{ data.latest("confidence-claim-rave-spec-untampered-001", "current").attributes.confidenceScore }}
+              - nodeId: "claim-swamp-models-valid-001"
+                nodeType: "claim"
+                status: "active"
+                confidenceScore: ${{ data.latest("confidence-claim-swamp-models-valid-001", "current").attributes.confidenceScore }}
+              - nodeId: "claim-swamp-workflows-valid-001"
+                nodeType: "claim"
+                status: "active"
+                confidenceScore: ${{ data.latest("confidence-claim-swamp-workflows-valid-001", "current").attributes.confidenceScore }}
+              - nodeId: "claim-unit-tests-pass-001"
+                nodeType: "claim"
+                status: "active"
+                confidenceScore: ${{ data.latest("confidence-claim-unit-tests-pass-001", "current").attributes.confidenceScore }}


### PR DESCRIPTION
## Summary

- Rewrites `rave_readiness_reporter.ts` to be scope-aware and node-count-agnostic: discovers all in-scope nodes by reading `rave/{claims,facts,validations,capabilities}/*.yaml` from disk, then cross-references live confidence scores from the `nodes` input array
- Emits a v0.2 readiness assessment shape: `raveVersion`, `evaluatedNodes[]`, `failingNodes[]`, `propagationTrace[]` (empty until edge support lands), `scope`, `includeDescendants`
- Rewrites the `readiness-check` workflow to pass all 16 active claims via a `nodes` array (same CEL-array pattern as `confidence-decay-sweep`); removes the 5-claim flat-arg limitation
- Adds `inScope` helper with descendant-inclusion rule (`startsWith(target + "/")`) and tests for exact/descendant/false-prefix cases
- Bumps manifest to `2026.05.07.1`, workflow `version` to `2`

## Test plan

- [x] `deno fmt --check extensions/models/` — clean
- [x] `deno lint extensions/models/` — clean
- [x] `deno check extensions/models/*.ts` — clean
- [x] `deno test extensions/models/rave_readiness_reporter.test.ts` — 15/15 pass
- [ ] `swamp extension validate` — run after merge on main
- [ ] `swamp workflow run readiness-check --json` — verify all 16 nodes in `evaluatedNodes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)