### PR TITLE
Bump yaml to 2.8.3 (GHSA-48c2-rrv3-qjmp)

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -7,8 +7,9 @@
     "jsr:@std/path@1": "1.1.4",
     "jsr:@std/yaml@1": "1.0.12",
     "jsr:@systeminit/swamp-testing@~0.20260424.9": "0.20260424.9",
-    "npm:yaml@2": "2.7.0",
+    "npm:yaml@2": "2.8.3",
     "npm:yaml@2.7.0": "2.7.0",
+    "npm:yaml@2.8.3": "2.8.3",
     "npm:zod@4": "4.3.6",
     "npm:zod@^4.3.6": "4.3.6"
   },
@@ -42,6 +43,10 @@
   "npm": {
     "yaml@2.7.0": {
       "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "bin": true
+    },
+    "yaml@2.8.3": {
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "bin": true
     },
     "zod@4.3.6": {

--- a/extensions/models/rave_readiness_reporter.ts
+++ b/extensions/models/rave_readiness_reporter.ts
@@ -1,5 +1,5 @@
 import { z } from "npm:zod@4";
-import { parse as parseYaml } from "npm:yaml@2.7.0";
+import { parse as parseYaml } from "npm:yaml@2.8.3";
 import { join } from "jsr:@std/path@1";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Bumps `npm:yaml` from `2.7.0` → `2.8.3` in `rave_readiness_reporter.ts`
- Fixes GHSA-48c2-rrv3-qjmp (medium, CVSS 4.3) — the only CVE flagged by the `cve-scan` CI job

## Test plan

- [x] `deno check extensions/models/rave_readiness_reporter.ts` — clean
- [ ] `validate` CI job `cve-scan` should pass green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)