### PR TITLE
Exclude sole maintainer from PR review check

### DIFF
--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -19,7 +19,7 @@ jobs:
           for PR in $(gh api "repos/mesgme/rave-swamp/pulls?state=closed&base=main&per_page=50" \
               --jq '.[] | select(.merged_at != null and .merged_at > "'"$SINCE"'") | .number'); do
             USER=$(gh api "repos/mesgme/rave-swamp/pulls/$PR" --jq '.user.login')
-            case "$USER" in renovate*|dependabot*|github-actions*) continue ;; esac
+            case "$USER" in renovate*|dependabot*|github-actions*|mellens) continue ;; esac
             APPROVED=$(gh api "repos/mesgme/rave-swamp/pulls/$PR/reviews" \
               --jq '[.[] | select(.state == "APPROVED")] | length')
             if [ "$APPROVED" -eq 0 ]; then

--- a/rave/claims/claim-merged-prs-reviewed-001.yaml
+++ b/rave/claims/claim-merged-prs-reviewed-001.yaml
@@ -1,6 +1,6 @@
 rave_version: "0.2.0"
 claim_id: claim-merged-prs-reviewed-001
-statement: Every PR merged to main in the last 30 days had at least one approving review before merge
+statement: Every PR merged to main in the last 30 days by a non-maintainer contributor had at least one approving review before merge
 owner:
   name: mellens
   contact: mesgme/rave-swamp
@@ -12,10 +12,11 @@ scope:
 assumptions:
   - The GitHub API pulls endpoint is authoritative for review state
   - PRs merged by bots (renovate, dependabot, github-actions) are excluded
-  - A single APPROVED review from any collaborator satisfies the claim
+  - PRs authored by the sole maintainer (mellens) are excluded — GitHub does not allow self-approval
+  - A single APPROVED review from any collaborator satisfies the claim for external contributors
 falsification_signals:
-  - Any merged PR in the last 30 days has zero APPROVED reviews
-  - A merge commit appears on main from a PR with only COMMENTED or CHANGES_REQUESTED reviews
+  - A PR authored by a non-maintainer contributor is merged with zero APPROVED reviews
+  - A merge commit appears on main from an external contributor's PR with only COMMENTED or CHANGES_REQUESTED reviews
 confidence:
   decay_lambda: 0.03
 annotations: []


### PR DESCRIPTION
## Summary

- Adds `mellens` to the exclusion list in the `pr-reviews` governance job, alongside bots (renovate, dependabot, github-actions)
- Updates `claim-merged-prs-reviewed-001` statement and assumptions to document the sole-maintainer exception
- The `commits-via-pr` job already enforces all changes arrive via PR; the review check is only meaningful for external contributors

## Why

GitHub does not allow self-approval. As sole maintainer, every PR authored by `mellens` was being flagged, causing the governance-check to fail nightly with 26+ violations.

## Test plan

- [ ] `governance-check` workflow passes on next scheduled run (or via `workflow_dispatch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)