### PR TITLE
Wire live CVE scan into deno task check

### DIFF
--- a/bin/rave-check.test.ts
+++ b/bin/rave-check.test.ts
@@ -1,6 +1,11 @@
 import { assertEquals } from "jsr:@std/assert@1";
-import { checkClaims, type CheckResult } from "./rave-check.ts";
+import {
+  checkClaims,
+  type CheckResult,
+  injectCveFindings,
+} from "./rave-check.ts";
 import type { Claim, ConfidenceData } from "./lib/types.ts";
+import type { CveFinding } from "./rave-cve-scan.ts";
 
 function makeClaim(overrides: Partial<Claim> = {}): Claim {
   return {
@@ -15,7 +20,9 @@ function makeClaim(overrides: Partial<Claim> = {}): Claim {
   };
 }
 
-function makeConfidence(overrides: Partial<ConfidenceData> = {}): ConfidenceData {
+function makeConfidence(
+  overrides: Partial<ConfidenceData> = {},
+): ConfidenceData {
   return {
     claimId: "claim-test-001",
     confidenceScore: 0.85,
@@ -58,11 +65,14 @@ Deno.test("checkClaims: ok=false when a claim is below threshold", () => {
 Deno.test("checkClaims: ok=false when a claim has non-empty guidance", () => {
   const claims = [makeClaim({ claim_id: "c1" })];
   const confidence = new Map([
-    ["c1", makeConfidence({
-      claimId: "c1",
-      confidenceScore: 0.85,
-      guidance: ["CI run failed on job test", "Check the Actions log"],
-    })],
+    [
+      "c1",
+      makeConfidence({
+        claimId: "c1",
+        confidenceScore: 0.85,
+        guidance: ["CI run failed on job test", "Check the Actions log"],
+      }),
+    ],
   ]);
   const result = checkClaims(claims, confidence, 0.7);
   assertEquals(result.ok, false);
@@ -99,4 +109,79 @@ Deno.test("checkClaims: result type is CheckResult", () => {
   const result: CheckResult = checkClaims([], new Map(), 0.7);
   assertEquals(result.ok, true);
   assertEquals(result.claims.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// injectCveFindings
+// ---------------------------------------------------------------------------
+
+function makeFinding(overrides: Partial<CveFinding> = {}): CveFinding {
+  return {
+    pkg: "yaml",
+    version: "2.7.0",
+    osvId: "GHSA-48c2-rrv3-qjmp",
+    severity: "CVSS_V3",
+    fixedVersion: "2.8.3",
+    ...overrides,
+  };
+}
+
+Deno.test("injectCveFindings: no-op when findings is empty", () => {
+  const confidence = new Map<string, ConfidenceData>();
+  injectCveFindings(confidence, []);
+  assertEquals(confidence.size, 0);
+});
+
+Deno.test("injectCveFindings: adds guidance to claim-no-known-cves-001", () => {
+  const confidence = new Map<string, ConfidenceData>();
+  injectCveFindings(confidence, [makeFinding()]);
+  const entry = confidence.get("claim-no-known-cves-001");
+  assertEquals(entry?.guidance.length, 1);
+  assertEquals(
+    entry?.guidance[0],
+    "GHSA-48c2-rrv3-qjmp [CVSS_V3] yaml@2.7.0 (fixed in 2.8.3)",
+  );
+});
+
+Deno.test("injectCveFindings: omits fix text when fixedVersion is null", () => {
+  const confidence = new Map<string, ConfidenceData>();
+  injectCveFindings(confidence, [makeFinding({ fixedVersion: null })]);
+  const entry = confidence.get("claim-no-known-cves-001");
+  assertEquals(entry?.guidance[0], "GHSA-48c2-rrv3-qjmp [CVSS_V3] yaml@2.7.0");
+});
+
+Deno.test("injectCveFindings: appends to existing guidance", () => {
+  const existing = makeConfidence({
+    claimId: "claim-no-known-cves-001",
+    guidance: ["prior guidance"],
+  });
+  const confidence = new Map([["claim-no-known-cves-001", existing]]);
+  injectCveFindings(confidence, [makeFinding()]);
+  assertEquals(confidence.get("claim-no-known-cves-001")?.guidance.length, 2);
+});
+
+Deno.test("injectCveFindings: preserves existing confidence score", () => {
+  const existing = makeConfidence({
+    claimId: "claim-no-known-cves-001",
+    confidenceScore: 0.75,
+  });
+  const confidence = new Map([["claim-no-known-cves-001", existing]]);
+  injectCveFindings(confidence, [makeFinding()]);
+  assertEquals(
+    confidence.get("claim-no-known-cves-001")?.confidenceScore,
+    0.75,
+  );
+});
+
+Deno.test("injectCveFindings: triggers checkClaims failure for CVE claim", () => {
+  const claim = makeClaim(
+    { claim_id: "claim-no-known-cves-001", confidenceScore: 0.85 } as never,
+  );
+  const claims = [{ ...claim, claim_id: "claim-no-known-cves-001" }];
+  const confidence = new Map<string, ConfidenceData>();
+  injectCveFindings(confidence, [makeFinding()]);
+  const result = checkClaims(claims, confidence, 0.7);
+  assertEquals(result.ok, false);
+  assertEquals(result.claims[0].claimId, "claim-no-known-cves-001");
+  assertEquals(result.claims[0].guidance.length, 1);
 });

--- a/bin/rave-check.ts
+++ b/bin/rave-check.ts
@@ -1,8 +1,11 @@
-import { parseScopeFile, flattenScopes } from "./lib/scopes.ts";
+import { flattenScopes, parseScopeFile } from "./lib/scopes.ts";
 import { parseClaimFiles } from "./lib/claims.ts";
 import { fetchAllConfidence } from "./lib/confidence.ts";
 import { confidenceLevel } from "./lib/render.ts";
 import type { Claim, ConfidenceData, ConfidenceLevel } from "./lib/types.ts";
+import { type CveFinding, scanLockfile } from "./rave-cve-scan.ts";
+
+const CVE_CLAIM_ID = "claim-no-known-cves-001";
 
 export interface CheckClaimRow {
   claimId: string;
@@ -40,14 +43,47 @@ export function checkClaims(
   return { ok: failing.length === 0, claims: failing };
 }
 
+/**
+ * Inject CVE findings as guidance into the confidence map for claim-no-known-cves-001.
+ * Exported for unit testing.
+ */
+export function injectCveFindings(
+  confidence: Map<string, ConfidenceData>,
+  findings: CveFinding[],
+): void {
+  if (findings.length === 0) return;
+  const existing = confidence.get(CVE_CLAIM_ID);
+  const guidance = findings.map((f) => {
+    const fix = f.fixedVersion ? ` (fixed in ${f.fixedVersion})` : "";
+    return `${f.osvId} [${f.severity}] ${f.pkg}@${f.version}${fix}`;
+  });
+  confidence.set(CVE_CLAIM_ID, {
+    claimId: CVE_CLAIM_ID,
+    confidenceScore: existing?.confidenceScore ?? 0,
+    previousScore: existing?.previousScore ?? null,
+    computedAt: existing?.computedAt ?? "",
+    lastValidated: existing?.lastValidated ?? "",
+    fAvg: existing?.fAvg ?? 0,
+    qAvg: existing?.qAvg ?? 0,
+    decayFactor: existing?.decayFactor ?? 0,
+    statusTransition: existing?.statusTransition ?? null,
+    guidance: [...(existing?.guidance ?? []), ...guidance],
+  });
+}
+
 async function main() {
   const repoDir = Deno.args.find((a) => !a.startsWith("-")) ?? ".";
   const threshold = 0.7;
 
-  const scopeTree = await parseScopeFile(`${repoDir}/rave/scopes/rave-swamp.yaml`);
+  const scopeTree = await parseScopeFile(
+    `${repoDir}/rave/scopes/rave-swamp.yaml`,
+  );
   const _flatScopes = flattenScopes(scopeTree);
   const claims = await parseClaimFiles(`${repoDir}/rave/claims`);
   const confidence = await fetchAllConfidence(claims.map((c) => c.claim_id));
+
+  const cveResult = await scanLockfile(`${repoDir}/deno.lock`);
+  injectCveFindings(confidence, cveResult.findings);
 
   const result = checkClaims(claims, confidence, threshold);
 

--- a/bin/rave-cve-scan.test.ts
+++ b/bin/rave-cve-scan.test.ts
@@ -1,0 +1,206 @@
+import { assertEquals } from "jsr:@std/assert@1";
+import {
+  type CveFinding,
+  findingsFromOsvResult,
+  parseNpmPackages,
+  queryOsv,
+  scanLockfile,
+} from "./rave-cve-scan.ts";
+
+// ---------------------------------------------------------------------------
+// parseNpmPackages
+// ---------------------------------------------------------------------------
+
+Deno.test("parseNpmPackages: extracts name and version from npm keys", () => {
+  const lock = {
+    npm: {
+      "yaml@2.7.0": { integrity: "abc" },
+      "zod@4.3.6": { integrity: "def" },
+    },
+  };
+  const pkgs = parseNpmPackages(lock);
+  assertEquals(pkgs.length, 2);
+  assertEquals(pkgs.find((p) => p.name === "yaml")?.version, "2.7.0");
+  assertEquals(pkgs.find((p) => p.name === "zod")?.version, "4.3.6");
+});
+
+Deno.test("parseNpmPackages: handles scoped packages (@scope/name@version)", () => {
+  const lock = {
+    npm: {
+      "@scope/pkg@1.2.3": { integrity: "abc" },
+    },
+  };
+  const pkgs = parseNpmPackages(lock);
+  assertEquals(pkgs.length, 1);
+  assertEquals(pkgs[0].name, "@scope/pkg");
+  assertEquals(pkgs[0].version, "1.2.3");
+});
+
+Deno.test("parseNpmPackages: returns empty array when no npm section", () => {
+  const pkgs = parseNpmPackages({});
+  assertEquals(pkgs.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// findingsFromOsvResult
+// ---------------------------------------------------------------------------
+
+Deno.test("findingsFromOsvResult: extracts osvId, severity, fixedVersion", () => {
+  const pkg = { name: "yaml", version: "2.7.0" };
+  const vulns = [
+    {
+      id: "GHSA-48c2-rrv3-qjmp",
+      severity: [{ type: "CVSS_V3", score: "CVSS:3.1/AV:N/AC:H" }],
+      affected: [
+        {
+          package: { name: "yaml", ecosystem: "npm" },
+          ranges: [
+            {
+              type: "SEMVER",
+              events: [{ introduced: "0" }, { fixed: "2.8.3" }],
+            },
+          ],
+        },
+      ],
+    },
+  ] as Array<Record<string, unknown>>;
+
+  const findings = findingsFromOsvResult(pkg, vulns);
+  assertEquals(findings.length, 1);
+  assertEquals(findings[0].osvId, "GHSA-48c2-rrv3-qjmp");
+  assertEquals(findings[0].severity, "CVSS_V3");
+  assertEquals(findings[0].fixedVersion, "2.8.3");
+  assertEquals(findings[0].pkg, "yaml");
+  assertEquals(findings[0].version, "2.7.0");
+});
+
+Deno.test("findingsFromOsvResult: returns empty array for no vulns", () => {
+  const findings = findingsFromOsvResult(
+    { name: "yaml", version: "2.8.3" },
+    [],
+  );
+  assertEquals(findings.length, 0);
+});
+
+Deno.test("findingsFromOsvResult: fixedVersion is null when no fix exists", () => {
+  const pkg = { name: "pkg", version: "1.0.0" };
+  const vulns = [
+    {
+      id: "GHSA-xxxx-xxxx-xxxx",
+      severity: [{ type: "HIGH" }],
+      affected: [
+        {
+          package: { name: "pkg", ecosystem: "npm" },
+          ranges: [{ type: "SEMVER", events: [{ introduced: "0" }] }],
+        },
+      ],
+    },
+  ] as Array<Record<string, unknown>>;
+  const findings = findingsFromOsvResult(pkg, vulns);
+  assertEquals(findings[0].fixedVersion, null);
+});
+
+Deno.test("findingsFromOsvResult: falls back to database_specific severity", () => {
+  const pkg = { name: "pkg", version: "1.0.0" };
+  const vulns = [
+    {
+      id: "GHSA-xxxx-yyyy-zzzz",
+      database_specific: { severity: "MEDIUM" },
+      affected: [],
+    },
+  ] as Array<Record<string, unknown>>;
+  const findings = findingsFromOsvResult(pkg, vulns);
+  assertEquals(findings[0].severity, "MEDIUM");
+});
+
+// ---------------------------------------------------------------------------
+// queryOsv (with mock fetch)
+// ---------------------------------------------------------------------------
+
+function makeFetch(responseBody: unknown): typeof fetch {
+  return (_url, _init) =>
+    Promise.resolve(
+      new Response(JSON.stringify(responseBody), { status: 200 }),
+    ) as ReturnType<typeof fetch>;
+}
+
+Deno.test("queryOsv: returns empty when no packages", async () => {
+  const findings = await queryOsv([], makeFetch({}));
+  assertEquals(findings.length, 0);
+});
+
+Deno.test("queryOsv: returns findings for vulnerable packages", async () => {
+  const response = {
+    results: [
+      {
+        vulns: [
+          {
+            id: "GHSA-48c2-rrv3-qjmp",
+            severity: [{ type: "CVSS_V3" }],
+            affected: [
+              {
+                package: { name: "yaml", ecosystem: "npm" },
+                ranges: [{
+                  type: "SEMVER",
+                  events: [{ introduced: "0" }, { fixed: "2.8.3" }],
+                }],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  const findings = await queryOsv(
+    [{ name: "yaml", version: "2.7.0" }],
+    makeFetch(response),
+  );
+  assertEquals(findings.length, 1);
+  assertEquals(findings[0].osvId, "GHSA-48c2-rrv3-qjmp");
+});
+
+Deno.test("queryOsv: returns empty for clean packages", async () => {
+  const response = { results: [{ vulns: [] }] };
+  const findings = await queryOsv(
+    [{ name: "zod", version: "4.3.6" }],
+    makeFetch(response),
+  );
+  assertEquals(findings.length, 0);
+});
+
+Deno.test("queryOsv: throws on non-200 response", async () => {
+  const badFetch = (_url: unknown, _init?: unknown) =>
+    Promise.resolve(new Response("", { status: 503 })) as ReturnType<
+      typeof fetch
+    >;
+  let threw = false;
+  try {
+    await queryOsv([{ name: "pkg", version: "1.0.0" }], badFetch);
+  } catch {
+    threw = true;
+  }
+  assertEquals(threw, true);
+});
+
+// ---------------------------------------------------------------------------
+// scanLockfile
+// ---------------------------------------------------------------------------
+
+Deno.test("scanLockfile: returns ok=true when lockfile does not exist", async () => {
+  const result = await scanLockfile("/nonexistent/path/deno.lock");
+  assertEquals(result.ok, true);
+  assertEquals(result.findings.length, 0);
+});
+
+Deno.test("scanLockfile: returns ok=true for lockfile with no npm packages", async () => {
+  const tmp = await Deno.makeTempFile({ suffix: ".lock" });
+  await Deno.writeTextFile(tmp, JSON.stringify({ npm: {} }));
+  try {
+    const result = await scanLockfile(tmp);
+    assertEquals(result.ok, true);
+    assertEquals(result.findings.length, 0);
+  } finally {
+    await Deno.remove(tmp);
+  }
+});

--- a/bin/rave-cve-scan.ts
+++ b/bin/rave-cve-scan.ts
@@ -1,0 +1,146 @@
+export interface NpmPackage {
+  name: string;
+  version: string;
+}
+
+export interface CveFinding {
+  pkg: string;
+  version: string;
+  osvId: string;
+  severity: string;
+  fixedVersion: string | null;
+}
+
+export interface CveScanResult {
+  ok: boolean;
+  findings: CveFinding[];
+}
+
+/** Parse npm packages from a parsed deno.lock object. */
+export function parseNpmPackages(lock: Record<string, unknown>): NpmPackage[] {
+  const npm = (lock["npm"] ?? {}) as Record<string, unknown>;
+  return Object.keys(npm).map((key) => {
+    const at = key.lastIndexOf("@");
+    return { name: key.slice(0, at), version: key.slice(at + 1) };
+  });
+}
+
+/** Build CveFindings from a single OSV query result entry. */
+export function findingsFromOsvResult(
+  pkg: NpmPackage,
+  vulns: Array<Record<string, unknown>>,
+): CveFinding[] {
+  return vulns.map((v) => {
+    const id = String(v["id"] ?? "");
+    const severity = pickSeverity(v);
+    const fixedVersion = pickFixedVersion(v, pkg.name);
+    return {
+      pkg: pkg.name,
+      version: pkg.version,
+      osvId: id,
+      severity,
+      fixedVersion,
+    };
+  });
+}
+
+function pickSeverity(vuln: Record<string, unknown>): string {
+  const severities = vuln["severity"] as
+    | Array<Record<string, string>>
+    | undefined;
+  if (severities?.length) return severities[0].type ?? "UNKNOWN";
+  const dbSpecific = vuln["database_specific"] as
+    | Record<string, unknown>
+    | undefined;
+  return String(dbSpecific?.["severity"] ?? "UNKNOWN");
+}
+
+function pickFixedVersion(
+  vuln: Record<string, unknown>,
+  pkgName: string,
+): string | null {
+  const affected = vuln["affected"] as
+    | Array<Record<string, unknown>>
+    | undefined;
+  if (!affected) return null;
+  for (const a of affected) {
+    const ap = a["package"] as Record<string, string> | undefined;
+    if (ap?.["name"] !== pkgName) continue;
+    const ranges = a["ranges"] as Array<Record<string, unknown>> | undefined;
+    if (!ranges) continue;
+    for (const r of ranges) {
+      const events = r["events"] as Array<Record<string, string>> | undefined;
+      if (!events) continue;
+      for (const e of events) {
+        if (e["fixed"]) return e["fixed"];
+      }
+    }
+  }
+  return null;
+}
+
+/** Query the OSV batch API for a list of npm packages. */
+export async function queryOsv(
+  packages: NpmPackage[],
+  fetch_: typeof fetch = fetch,
+): Promise<CveFinding[]> {
+  if (packages.length === 0) return [];
+
+  const body = {
+    queries: packages.map((p) => ({
+      package: { name: p.name, version: p.version, ecosystem: "npm" },
+    })),
+  };
+
+  const res = await fetch_("https://api.osv.dev/v1/querybatch", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    throw new Error(`OSV API error: ${res.status} ${res.statusText}`);
+  }
+
+  const data = (await res.json()) as {
+    results: Array<{ vulns?: Array<Record<string, unknown>> }>;
+  };
+  const findings: CveFinding[] = [];
+
+  for (let i = 0; i < packages.length; i++) {
+    const vulns = data.results[i]?.vulns ?? [];
+    findings.push(...findingsFromOsvResult(packages[i], vulns));
+  }
+
+  return findings;
+}
+
+/** Read deno.lock and return CVE scan results. */
+export async function scanLockfile(lockPath: string): Promise<CveScanResult> {
+  let lock: Record<string, unknown>;
+  try {
+    lock = JSON.parse(await Deno.readTextFile(lockPath));
+  } catch {
+    return { ok: true, findings: [] };
+  }
+
+  const packages = parseNpmPackages(lock);
+  const findings = await queryOsv(packages);
+  return { ok: findings.length === 0, findings };
+}
+
+if (import.meta.main) {
+  const lockPath = Deno.args[0] ?? "deno.lock";
+  const result = await scanLockfile(lockPath);
+
+  if (result.ok) {
+    console.log("No CVEs found in npm dependencies.");
+    Deno.exit(0);
+  }
+
+  for (const f of result.findings) {
+    const fix = f.fixedVersion ? ` (fixed in ${f.fixedVersion})` : "";
+    console.error(`${f.osvId} [${f.severity}] ${f.pkg}@${f.version}${fix}`);
+  }
+  Deno.exit(1);
+}

--- a/deno.json
+++ b/deno.json
@@ -10,8 +10,9 @@
   "tasks": {
     "dashboard": "deno run --allow-read --allow-run=swamp bin/rave-dashboard.ts",
     "dashboard:json": "deno run --allow-read --allow-run=swamp bin/rave-dashboard.ts --json",
-    "dashboard:test": "deno test --allow-read bin/",
-    "check": "deno run --allow-read --allow-run=swamp bin/rave-check.ts"
+    "dashboard:test": "deno test --allow-read --allow-write bin/",
+    "cve-scan": "deno run --allow-read --allow-net=api.osv.dev bin/rave-cve-scan.ts",
+    "check": "deno run --allow-read --allow-run=swamp --allow-net=api.osv.dev bin/rave-check.ts"
   },
   "imports": {
     "@systeminit/swamp-testing": "jsr:@systeminit/swamp-testing@^0.20260424.9"


### PR DESCRIPTION
## Summary

- Adds `bin/rave-cve-scan.ts` — reads `deno.lock`, queries the [OSV batch API](https://api.osv.dev/) for all npm packages, and returns structured findings; exposed as `deno task cve-scan` for standalone use
- Wires the CVE scan into `bin/rave-check.ts` (`deno task check`) — findings are injected as guidance on `claim-no-known-cves-001` before back-pressure evaluation, so `deno task check` fails immediately if `deno.lock` contains a known-vulnerable package
- Adds `--allow-write` to `dashboard:test` for temp-file tests
- 93 tests pass (13 new for `rave-cve-scan.ts`, 6 new for `injectCveFindings` in `rave-check.test.ts`)

## Context

Prior to this PR, `deno task check` was a confidence check against swamp-gathered data — it reflected CI state on main, not local state. A vulnerable package in `deno.lock` on a feature branch would fail CI's `cve-scan` job but pass `deno task check` locally, giving no pre-push warning. This PR closes that gap.

## Test plan

- [x] `deno fmt --check extensions/models/ bin/` passes
- [x] `deno lint extensions/models/ bin/` passes
- [x] `deno check extensions/models/*.ts bin/*.ts` passes
- [x] `deno task dashboard:test` — 93 tests pass
- [ ] Manual verification: temporarily add `npm:yaml@2.7.0` as an import, run `deno cache` to update the lock, run `deno task check` — should fail with CVE guidance on `claim-no-known-cves-001`
- [ ] Manual verification: `deno task cve-scan` reports no findings on the clean lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)