### PR TITLE
M1: Add rave_service_descriptor model

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -5,6 +5,7 @@
     "jsr:@std/assert@1.0.19": "1.0.19",
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/path@1": "1.1.4",
+    "jsr:@std/yaml@1": "1.0.12",
     "jsr:@systeminit/swamp-testing@~0.20260424.9": "0.20260424.9",
     "npm:yaml@2.8.3": "2.8.3",
     "npm:zod@4": "4.3.6",
@@ -25,6 +26,9 @@
       "dependencies": [
         "jsr:@std/internal"
       ]
+    },
+    "@std/yaml@1.0.12": {
+      "integrity": "7deabca4545bcedd07c5f69ea53acea71b8b4c67562f224e17b90d75944cb20c"
     },
     "@systeminit/swamp-testing@0.20260424.9": {
       "integrity": "c2364e542bbb5f03cda94aaba070be8710c9533423bbb36c91bd12ce2a45bbc5",

--- a/extensions/models/rave_service_descriptor.test.ts
+++ b/extensions/models/rave_service_descriptor.test.ts
@@ -1,0 +1,351 @@
+import { assertEquals, assertExists } from "jsr:@std/assert@1";
+import { createModelTestContext } from "@systeminit/swamp-testing";
+import { model } from "./rave_service_descriptor.ts";
+
+// The test harness types written data as `unknown`; cast to access typed fields.
+type Descriptor = {
+  outcome: string;
+  summary: string;
+  timestamp: string;
+  attestedAt: string;
+  isStale: boolean;
+  rawData: string;
+  failureReason: string | null;
+  remediation: string | null;
+  criticalDepsDocumented: boolean;
+  undocumentedCriticalDeps: string[];
+  sloComplete: boolean;
+  incompleteEndpoints: string[];
+};
+
+const BASE_GLOBAL_ARGS = {
+  serviceId: "rave-swamp",
+  repo: "mesgme/rave-swamp",
+};
+
+const OWNER = {
+  name: "Mark Ellens",
+  team: "rave-core",
+  confirmedAt: "2026-06-24T00:00:00.000Z",
+};
+
+const CRITICAL_DEP_DOCUMENTED = {
+  name: "github-api",
+  type: "external-api" as const,
+  criticality: "critical" as const,
+  sla: "99.9% availability per month",
+  fallbackPlan: "Queue writes and replay once API recovers",
+};
+
+const STANDARD_DEP_UNDOCUMENTED = {
+  name: "some-library",
+  type: "library" as const,
+  criticality: "standard" as const,
+  // no sla or fallbackPlan — standard deps are exempt
+};
+
+const SLO_COMPLETE = {
+  endpoint: "/api/health",
+  target: 0.999,
+  window: "30d",
+};
+
+// ---------------------------------------------------------------------------
+// Pass case
+// ---------------------------------------------------------------------------
+
+Deno.test("service-descriptor: pass — owner + documented critical deps + complete SLOs", async () => {
+  const { context, getWrittenResources } = createModelTestContext({
+    globalArgs: BASE_GLOBAL_ARGS,
+    methodName: "declare",
+  });
+
+  await model.methods.declare.execute(
+    {
+      owner: OWNER,
+      dependencies: [CRITICAL_DEP_DOCUMENTED, STANDARD_DEP_UNDOCUMENTED],
+      slos: [SLO_COMPLETE],
+      attestedBy: "mellens",
+    },
+    context,
+  );
+
+  const [res] = getWrittenResources();
+  const data = res.data as Descriptor;
+  assertEquals(data.outcome, "pass");
+  assertEquals(data.criticalDepsDocumented, true);
+  assertEquals(data.undocumentedCriticalDeps, []);
+  assertEquals(data.sloComplete, true);
+  assertEquals(data.incompleteEndpoints, []);
+  assertEquals(data.failureReason, null);
+  assertEquals(data.remediation, null);
+  assertEquals(data.isStale, false);
+
+  // timestamp must equal attestedAt (staleness falsifier depends on this)
+  assertExists(data.attestedAt);
+  assertEquals(data.timestamp, data.attestedAt);
+
+  // rawData must be valid JSON containing the derived booleans
+  const raw = JSON.parse(data.rawData);
+  assertEquals(raw.criticalDepsDocumented, true);
+  assertEquals(raw.sloComplete, true);
+  assertEquals(raw.outcome, "pass");
+});
+
+// ---------------------------------------------------------------------------
+// Fail: undocumented critical dep
+// ---------------------------------------------------------------------------
+
+Deno.test("service-descriptor: fail — critical dep missing fallbackPlan", async () => {
+  const { context, getWrittenResources } = createModelTestContext({
+    globalArgs: BASE_GLOBAL_ARGS,
+    methodName: "declare",
+  });
+
+  await model.methods.declare.execute(
+    {
+      owner: OWNER,
+      dependencies: [
+        {
+          name: "github-api",
+          type: "external-api",
+          criticality: "critical",
+          sla: "99.9% availability per month",
+          // fallbackPlan omitted — should trigger undocumented
+        },
+      ],
+      slos: [SLO_COMPLETE],
+      attestedBy: "mellens",
+    },
+    context,
+  );
+
+  const [res] = getWrittenResources();
+  const data = res.data as Descriptor;
+  assertEquals(data.outcome, "fail");
+  assertEquals(data.criticalDepsDocumented, false);
+  assertEquals(data.undocumentedCriticalDeps, ["github-api"]);
+  assertEquals(data.sloComplete, true); // SLO is fine
+  assertExists(data.failureReason);
+  assertExists(data.remediation);
+  assertEquals(typeof data.failureReason, "string");
+  assertEquals(typeof data.remediation, "string");
+
+  // rawData reflects the failure
+  const raw = JSON.parse(data.rawData);
+  assertEquals(raw.criticalDepsDocumented, false);
+  assertEquals(raw.undocumentedCriticalDeps, ["github-api"]);
+});
+
+Deno.test("service-descriptor: fail — critical dep missing both sla and fallbackPlan", async () => {
+  const { context, getWrittenResources } = createModelTestContext({
+    globalArgs: BASE_GLOBAL_ARGS,
+    methodName: "declare",
+  });
+
+  await model.methods.declare.execute(
+    {
+      owner: OWNER,
+      dependencies: [
+        {
+          name: "postgres",
+          type: "database",
+          criticality: "critical",
+          // sla and fallbackPlan both missing
+        },
+      ],
+      slos: [SLO_COMPLETE],
+      attestedBy: "mellens",
+    },
+    context,
+  );
+
+  const [res] = getWrittenResources();
+  const data = res.data as Descriptor;
+  assertEquals(data.outcome, "fail");
+  assertEquals(data.criticalDepsDocumented, false);
+  assertEquals(data.undocumentedCriticalDeps, ["postgres"]);
+});
+
+// ---------------------------------------------------------------------------
+// Fail: incomplete SLO
+// ---------------------------------------------------------------------------
+
+Deno.test("service-descriptor: fail — SLO entry missing window", async () => {
+  const { context, getWrittenResources } = createModelTestContext({
+    globalArgs: BASE_GLOBAL_ARGS,
+    methodName: "declare",
+  });
+
+  await model.methods.declare.execute(
+    {
+      owner: OWNER,
+      dependencies: [CRITICAL_DEP_DOCUMENTED],
+      slos: [
+        {
+          endpoint: "/api/health",
+          target: 0.999,
+          // window omitted — incomplete
+        },
+      ],
+      attestedBy: "mellens",
+    },
+    context,
+  );
+
+  const [res] = getWrittenResources();
+  const data = res.data as Descriptor;
+  assertEquals(data.outcome, "fail");
+  assertEquals(data.sloComplete, false);
+  assertEquals(data.incompleteEndpoints, ["/api/health"]);
+  assertEquals(data.criticalDepsDocumented, true); // deps are fine
+  assertExists(data.failureReason);
+
+  const raw = JSON.parse(data.rawData);
+  assertEquals(raw.sloComplete, false);
+  assertEquals(raw.incompleteEndpoints, ["/api/health"]);
+});
+
+Deno.test("service-descriptor: fail — SLO entry missing target", async () => {
+  const { context, getWrittenResources } = createModelTestContext({
+    globalArgs: BASE_GLOBAL_ARGS,
+    methodName: "declare",
+  });
+
+  await model.methods.declare.execute(
+    {
+      owner: OWNER,
+      dependencies: [CRITICAL_DEP_DOCUMENTED],
+      slos: [
+        {
+          endpoint: "/api/search",
+          // target omitted
+          window: "30d",
+        },
+      ],
+      attestedBy: "mellens",
+    },
+    context,
+  );
+
+  const [res] = getWrittenResources();
+  const data = res.data as Descriptor;
+  assertEquals(data.outcome, "fail");
+  assertEquals(data.sloComplete, false);
+  assertEquals(data.incompleteEndpoints, ["/api/search"]);
+});
+
+// ---------------------------------------------------------------------------
+// Standard-criticality deps are exempt from documentation requirement
+// ---------------------------------------------------------------------------
+
+Deno.test("service-descriptor: standard dep without sla/fallbackPlan does not affect criticalDepsDocumented", async () => {
+  const { context, getWrittenResources } = createModelTestContext({
+    globalArgs: BASE_GLOBAL_ARGS,
+    methodName: "declare",
+  });
+
+  await model.methods.declare.execute(
+    {
+      owner: OWNER,
+      dependencies: [
+        CRITICAL_DEP_DOCUMENTED, // critical — fully documented
+        STANDARD_DEP_UNDOCUMENTED, // standard — undocumented, but that's fine
+        {
+          name: "another-lib",
+          type: "library",
+          criticality: "standard",
+          // no sla or fallbackPlan
+        },
+      ],
+      slos: [SLO_COMPLETE],
+      attestedBy: "mellens",
+    },
+    context,
+  );
+
+  const [res] = getWrittenResources();
+  const data = res.data as Descriptor;
+  assertEquals(data.outcome, "pass");
+  assertEquals(data.criticalDepsDocumented, true);
+  assertEquals(data.undocumentedCriticalDeps, []);
+});
+
+// ---------------------------------------------------------------------------
+// Both fail conditions simultaneously
+// ---------------------------------------------------------------------------
+
+Deno.test("service-descriptor: fail — both undocumented critical dep and incomplete SLO", async () => {
+  const { context, getWrittenResources } = createModelTestContext({
+    globalArgs: BASE_GLOBAL_ARGS,
+    methodName: "declare",
+  });
+
+  await model.methods.declare.execute(
+    {
+      owner: OWNER,
+      dependencies: [
+        {
+          name: "redis",
+          type: "database",
+          criticality: "critical",
+          // sla and fallbackPlan both missing
+        },
+      ],
+      slos: [
+        {
+          endpoint: "/api/write",
+          target: 0.99,
+          // window missing
+        },
+      ],
+      attestedBy: "mellens",
+    },
+    context,
+  );
+
+  const [res] = getWrittenResources();
+  const data = res.data as Descriptor;
+  assertEquals(data.outcome, "fail");
+  assertEquals(data.criticalDepsDocumented, false);
+  assertEquals(data.sloComplete, false);
+  assertExists(data.failureReason);
+  // summary should mention both issues
+  assertEquals(
+    data.summary.includes("undocumented critical deps"),
+    true,
+  );
+  assertEquals(
+    data.summary.includes("incomplete SLO entries"),
+    true,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Empty arrays (no deps, no SLOs) — should pass (nothing to fail)
+// ---------------------------------------------------------------------------
+
+Deno.test("service-descriptor: pass — no dependencies, no SLOs", async () => {
+  const { context, getWrittenResources } = createModelTestContext({
+    globalArgs: BASE_GLOBAL_ARGS,
+    methodName: "declare",
+  });
+
+  await model.methods.declare.execute(
+    {
+      owner: OWNER,
+      dependencies: [],
+      slos: [],
+      attestedBy: "mellens",
+    },
+    context,
+  );
+
+  const [res] = getWrittenResources();
+  const data = res.data as Descriptor;
+  assertEquals(data.outcome, "pass");
+  assertEquals(data.criticalDepsDocumented, true);
+  assertEquals(data.sloComplete, true);
+  assertEquals(data.undocumentedCriticalDeps, []);
+  assertEquals(data.incompleteEndpoints, []);
+});

--- a/extensions/models/rave_service_descriptor.ts
+++ b/extensions/models/rave_service_descriptor.ts
@@ -1,0 +1,175 @@
+import { z } from "npm:zod@4";
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+const OwnerSchema = z.object({
+  name: z.string(),
+  team: z.string(),
+  confirmedAt: z.string(), // ISO8601
+});
+
+const DependencySchema = z.object({
+  name: z.string(),
+  type: z.enum(["service", "database", "queue", "external-api", "library"]),
+  criticality: z.enum(["critical", "standard"]),
+  sla: z.string().optional(), // documented SLA; required for critical deps
+  fallbackPlan: z.string().optional(), // fallback when this dep is down; required for critical deps
+});
+
+// Optional target/window to allow incomplete declarations (sloComplete derivation checks for them).
+const SloSchema = z.object({
+  endpoint: z.string(),
+  target: z.number().optional(), // e.g. 0.999
+  window: z.string().optional(), // e.g. "30d"
+});
+
+const GlobalArgsSchema = z.object({
+  serviceId: z.string(),
+  repo: z.string(), // e.g. "mesgme/rave-swamp"
+});
+
+const ResultSchema = z.object({
+  serviceId: z.string(),
+  owner: OwnerSchema,
+  dependencies: z.array(DependencySchema),
+  slos: z.array(SloSchema),
+  attestedBy: z.string(),
+  attestedAt: z.string(), // ISO8601 — time of this attestation; used as timestamp for staleness
+
+  // Derived fields (computed by declare; readable via JSONPath on rawData)
+  criticalDepsDocumented: z.boolean(), // true when no critical dep is missing sla or fallbackPlan
+  undocumentedCriticalDeps: z.array(z.string()),
+  sloComplete: z.boolean(), // true when every SLO entry has both target and window
+  incompleteEndpoints: z.array(z.string()),
+
+  // Standard evidence fields (match rave_ci_evidence / rave_github_api_evidence conventions)
+  outcome: z.enum(["pass", "fail", "inconclusive"]),
+  summary: z.string(),
+  timestamp: z.string(), // = attestedAt; staleness falsifier (max_age: P90D) reads this
+  isStale: z.boolean(), // false at write time; confidence engine applies decay separately
+  rawData: z.string(), // JSON.stringify of derived payload; falsifiers JSONPath $.criticalDepsDocumented / $.sloComplete
+  failureReason: z.string().nullable(), // non-null only on "fail"
+  remediation: z.string().nullable(), // non-null only on "fail"
+});
+
+// ---------------------------------------------------------------------------
+// Model
+// ---------------------------------------------------------------------------
+
+export const model = {
+  type: "@mellens/rave/service-descriptor",
+  version: "2026.06.24.1",
+  globalArguments: GlobalArgsSchema,
+  resources: {
+    descriptor: {
+      description:
+        "Current service descriptor — ownership, dependencies, and SLOs; multiple claims read derived fields via falsifier JSONPath",
+      schema: ResultSchema,
+      lifetime: "180d",
+      garbageCollection: 90,
+    },
+  },
+  methods: {
+    declare: {
+      description:
+        "Record a human-attested service descriptor (owner, deps, SLOs); compute criticalDepsDocumented and sloComplete",
+      arguments: z.object({
+        owner: OwnerSchema,
+        dependencies: z.array(DependencySchema),
+        slos: z.array(SloSchema),
+        attestedBy: z.string(),
+      }),
+      execute: async (args, context) => {
+        const { serviceId } = context.globalArgs;
+        const { owner, dependencies, slos, attestedBy } = args;
+        const attestedAt = new Date().toISOString();
+
+        // --- Derive critical-dep completeness ---
+        // A critical dep must have both sla and fallbackPlan documented.
+        const undocumentedCriticalDeps = dependencies
+          .filter((d) =>
+            d.criticality === "critical" && (!d.sla || !d.fallbackPlan)
+          )
+          .map((d) => d.name);
+        const criticalDepsDocumented = undocumentedCriticalDeps.length === 0;
+
+        // --- Derive SLO completeness ---
+        // Every SLO entry must declare both a numeric target and a measurement window.
+        const incompleteEndpoints = slos
+          .filter((s) => s.target === undefined || s.window === undefined)
+          .map((s) => s.endpoint);
+        const sloComplete = incompleteEndpoints.length === 0;
+
+        // --- Outcome ---
+        const outcome: "pass" | "fail" = criticalDepsDocumented && sloComplete
+          ? "pass"
+          : "fail";
+
+        const failureReasons: string[] = [];
+        if (!criticalDepsDocumented) {
+          failureReasons.push(
+            `undocumented critical deps: ${
+              undocumentedCriticalDeps.join(", ")
+            }`,
+          );
+        }
+        if (!sloComplete) {
+          failureReasons.push(
+            `incomplete SLO entries: ${incompleteEndpoints.join(", ")}`,
+          );
+        }
+
+        const summary = outcome === "pass"
+          ? `Service descriptor for ${serviceId}: all checks pass`
+          : `Service descriptor for ${serviceId}: ${failureReasons.join("; ")}`;
+
+        const failureReason = outcome === "fail" ? summary : null;
+        const remediation = outcome === "fail"
+          ? `Re-run 'rave_service_descriptor declare' with complete data: ` +
+            `critical deps need sla + fallbackPlan; every SLO endpoint needs target + window`
+          : null;
+
+        // rawData: JSON-serialised payload readable by falsifier-engine JSONPath.
+        // Includes derived booleans so falsifiers can evaluate $.criticalDepsDocumented and $.sloComplete.
+        const rawData = JSON.stringify({
+          serviceId,
+          criticalDepsDocumented,
+          undocumentedCriticalDeps,
+          sloComplete,
+          incompleteEndpoints,
+          outcome,
+          attestedBy,
+          attestedAt,
+        });
+
+        context.logger.info(
+          `${serviceId}: outcome=${outcome}, criticalDepsDocumented=${criticalDepsDocumented}, sloComplete=${sloComplete}`,
+        );
+
+        const handle = await context.writeResource("descriptor", "current", {
+          serviceId,
+          owner,
+          dependencies,
+          slos,
+          attestedBy,
+          attestedAt,
+          criticalDepsDocumented,
+          undocumentedCriticalDeps,
+          sloComplete,
+          incompleteEndpoints,
+          outcome,
+          summary,
+          timestamp: attestedAt, // staleness falsifier reads this
+          isStale: false,
+          rawData,
+          failureReason,
+          remediation,
+        });
+
+        return { dataHandles: [handle] };
+      },
+    },
+  },
+};

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,6 @@
 manifestVersion: 1
 name: "@mellens/rave"
-version: "2026.05.07.1"
+version: "2026.06.24.1"
 description: "RAVE (Reliability & Validation Engineering) — confidence scoring with exponential decay, claim lifecycle management, evidence gathering from GitHub and Prometheus, falsification detection, and readiness gating for software reliability claims"
 models:
   - rave_claim.ts
@@ -11,6 +11,7 @@ models:
   - rave_falsifier_engine.ts
   - rave_readiness_reporter.ts
   - rave_diff_evidence.ts
+  - rave_service_descriptor.ts
 labels:
   - rave
   - reliability

--- a/models/@mellens/rave/service-descriptor/df671a5f-de13-4392-b531-054b1a84b525.yaml
+++ b/models/@mellens/rave/service-descriptor/df671a5f-de13-4392-b531-054b1a84b525.yaml
@@ -1,0 +1,10 @@
+type: '@mellens/rave/service-descriptor'
+typeVersion: 2026.06.24.1
+id: df671a5f-de13-4392-b531-054b1a84b525
+name: service-descriptor-rave-swamp-001
+version: 1
+tags: {}
+globalArguments:
+  serviceId: rave-swamp
+  repo: mesgme/rave-swamp
+methods: {}


### PR DESCRIPTION
Closes #89. Part of epic #88.

## Summary

- Adds `extensions/models/rave_service_descriptor.ts` — a generalised, SBOM-like swamp model that records ownership, dependencies, and SLOs for a service and computes derived completeness fields
- Adds `extensions/models/rave_service_descriptor.test.ts` — 8 unit tests covering all pass/fail cases
- Registers the model in `manifest.yaml` (bumps package version to `2026.06.24.1`)
- Creates `service-descriptor-rave-swamp-001` instance with `serviceId: rave-swamp, repo: mesgme/rave-swamp`

## Design highlights

| Concern | How it's handled |
|---|---|
| Ownership staleness | `timestamp = attestedAt` so a staleness falsifier (`max_age: P90D`) decays as time passes since last re-attestation |
| Boolean falsifiers | `rawData = JSON.stringify(derived fields)` so falsifiers can JSONPath `$.criticalDepsDocumented` / `$.sloComplete` |
| Standard shape | Matches `rave_ci_evidence` conventions: `outcome/summary/isStale/failureReason/remediation` |

## Also in this PR (from issue reconciliation)
Issues #88, #90, #91, #92 were updated before this PR to align with the revised service-descriptor design (dropping the obsolete `rave_attestation_evidence` references).

## Test plan

- [x] `deno fmt --check extensions/models/` — clean
- [x] `deno lint extensions/models/` — clean
- [x] `deno check extensions/models/*.ts` — clean
- [x] `deno test extensions/models/rave_service_descriptor.test.ts` — 8/8 pass
- [x] `deno task dashboard:test` — 93/93 pass
- [x] `swamp extension fmt manifest.yaml` — clean (version drift warnings are pre-existing on other models)
- [x] `swamp model get service-descriptor-rave-swamp-001 --json` — instance exists with correct global args

🤖 Generated with [Claude Code](https://claude.com/claude-code)