### PR TITLE
M2 (#90): rave-assess interactive questionnaire CLI + questions catalog

### DIFF
--- a/bin/rave-assess.test.ts
+++ b/bin/rave-assess.test.ts
@@ -1,0 +1,282 @@
+import { assertEquals, assertRejects } from "jsr:@std/assert@1";
+import {
+  buildDeclarePayload,
+  type DescriptorFile,
+  getPendingQuestions,
+  isStale,
+  loadQuestions,
+  parseDurationMs,
+  type Question,
+} from "./rave-assess.ts";
+
+// ---------------------------------------------------------------------------
+// parseDurationMs
+// ---------------------------------------------------------------------------
+
+Deno.test("parseDurationMs: P90D", () => {
+  assertEquals(parseDurationMs("P90D"), 90 * 24 * 60 * 60 * 1000);
+});
+
+Deno.test("parseDurationMs: P1D", () => {
+  assertEquals(parseDurationMs("P1D"), 24 * 60 * 60 * 1000);
+});
+
+Deno.test("parseDurationMs: P30D", () => {
+  assertEquals(parseDurationMs("P30D"), 30 * 24 * 60 * 60 * 1000);
+});
+
+Deno.test("parseDurationMs: unsupported format throws", () => {
+  let threw = false;
+  try {
+    parseDurationMs("PT1H");
+  } catch {
+    threw = true;
+  }
+  assertEquals(threw, true);
+});
+
+// ---------------------------------------------------------------------------
+// isStale
+// ---------------------------------------------------------------------------
+
+const NOW = new Date("2026-06-26T00:00:00.000Z");
+
+Deno.test("isStale: timestamp within P90D is fresh", () => {
+  const recent = new Date(NOW.getTime() - 10 * 24 * 60 * 60 * 1000)
+    .toISOString();
+  assertEquals(isStale(recent, "P90D", NOW), false);
+});
+
+Deno.test("isStale: timestamp older than P90D is stale", () => {
+  const old = new Date(NOW.getTime() - 91 * 24 * 60 * 60 * 1000).toISOString();
+  assertEquals(isStale(old, "P90D", NOW), true);
+});
+
+Deno.test("isStale: null timestamp is stale", () => {
+  assertEquals(isStale(null, "P90D", NOW), true);
+});
+
+Deno.test("isStale: undefined timestamp is stale", () => {
+  assertEquals(isStale(undefined, "P90D", NOW), true);
+});
+
+Deno.test("isStale: empty string timestamp is stale", () => {
+  assertEquals(isStale("", "P90D", NOW), true);
+});
+
+Deno.test("isStale: invalid timestamp string is stale", () => {
+  assertEquals(isStale("not-a-date", "P90D", NOW), true);
+});
+
+Deno.test("isStale: exactly at freshness boundary is fresh", () => {
+  // Exactly 90 days ago — not strictly older than 90d
+  const exactly = new Date(NOW.getTime() - 90 * 24 * 60 * 60 * 1000)
+    .toISOString();
+  assertEquals(isStale(exactly, "P90D", NOW), false);
+});
+
+// ---------------------------------------------------------------------------
+// loadQuestions
+// ---------------------------------------------------------------------------
+
+async function withTempDir(
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await Deno.makeTempDir();
+  try {
+    await fn(dir);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+}
+
+const VALID_QUESTION_YAML = `
+question_id: q-test-001
+claim_id: claim-test-001
+evidence_id: evidence-test-001
+descriptor: my-service
+instance: service-descriptor-my-service-001
+prompt: Is the recorded owner still accurate?
+answer_type: yes_no
+expected_answer: "yes"
+freshness_window: P90D
+`;
+
+Deno.test("loadQuestions: parses a valid question file", async () => {
+  await withTempDir(async (dir) => {
+    await Deno.writeTextFile(`${dir}/q-test-001.yaml`, VALID_QUESTION_YAML);
+    const questions = await loadQuestions(dir);
+    assertEquals(questions.length, 1);
+    assertEquals(questions[0].question_id, "q-test-001");
+    assertEquals(questions[0].claim_id, "claim-test-001");
+    assertEquals(questions[0].freshness_window, "P90D");
+  });
+});
+
+Deno.test("loadQuestions: ignores non-yaml files", async () => {
+  await withTempDir(async (dir) => {
+    await Deno.writeTextFile(`${dir}/q-test-001.yaml`, VALID_QUESTION_YAML);
+    await Deno.writeTextFile(`${dir}/README.md`, "# readme");
+    await Deno.writeTextFile(`${dir}/notes.txt`, "notes");
+    const questions = await loadQuestions(dir);
+    assertEquals(questions.length, 1);
+  });
+});
+
+Deno.test("loadQuestions: sorts by question_id", async () => {
+  await withTempDir(async (dir) => {
+    await Deno.writeTextFile(
+      `${dir}/q-zzz.yaml`,
+      VALID_QUESTION_YAML.replace("q-test-001", "q-zzz-001"),
+    );
+    await Deno.writeTextFile(
+      `${dir}/q-aaa.yaml`,
+      VALID_QUESTION_YAML.replace("q-test-001", "q-aaa-001"),
+    );
+    const questions = await loadQuestions(dir);
+    assertEquals(questions[0].question_id, "q-aaa-001");
+    assertEquals(questions[1].question_id, "q-zzz-001");
+  });
+});
+
+Deno.test("loadQuestions: throws on missing required field", async () => {
+  await withTempDir(async (dir) => {
+    const broken = VALID_QUESTION_YAML.replace(
+      "freshness_window: P90D",
+      "",
+    );
+    await Deno.writeTextFile(`${dir}/q-broken.yaml`, broken);
+    await assertRejects(
+      () => loadQuestions(dir),
+      Error,
+      "freshness_window",
+    );
+  });
+});
+
+Deno.test("loadQuestions: returns empty array for empty dir", async () => {
+  await withTempDir(async (dir) => {
+    const questions = await loadQuestions(dir);
+    assertEquals(questions.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildDeclarePayload
+// ---------------------------------------------------------------------------
+
+const DESCRIPTOR: DescriptorFile = {
+  owner: {
+    name: "Alice",
+    team: "Platform",
+    confirmedAt: "2026-06-01T00:00:00.000Z",
+  },
+  dependencies: [
+    {
+      name: "github-actions",
+      type: "external-api",
+      criticality: "critical",
+      sla: "99.9%",
+      fallbackPlan: "Manual attestation",
+    },
+  ],
+  slos: [{ endpoint: "/health", target: 0.999, window: "30d" }],
+};
+
+Deno.test("buildDeclarePayload: injects attestedBy", () => {
+  const payload = buildDeclarePayload(DESCRIPTOR, "alice@example.com");
+  assertEquals(payload.attestedBy, "alice@example.com");
+  assertEquals(payload.owner, DESCRIPTOR.owner);
+  assertEquals(payload.dependencies, DESCRIPTOR.dependencies);
+  assertEquals(payload.slos, DESCRIPTOR.slos);
+});
+
+Deno.test("buildDeclarePayload: does not include extra keys", () => {
+  const payload = buildDeclarePayload(DESCRIPTOR, "alice@example.com");
+  const keys = Object.keys(payload).sort();
+  assertEquals(keys, ["attestedBy", "dependencies", "owner", "slos"]);
+});
+
+// ---------------------------------------------------------------------------
+// getPendingQuestions
+// ---------------------------------------------------------------------------
+
+function makeQuestion(overrides: Partial<Question> = {}): Question {
+  return {
+    question_id: "q-test-001",
+    claim_id: "claim-test-001",
+    evidence_id: "evidence-test-001",
+    descriptor: "my-service",
+    instance: "service-descriptor-my-service-001",
+    prompt: "Is the owner correct?",
+    answer_type: "yes_no",
+    expected_answer: "yes",
+    freshness_window: "P90D",
+    ...overrides,
+  };
+}
+
+Deno.test("getPendingQuestions: fresh question is not pending", async () => {
+  const q = makeQuestion();
+  const recent = new Date(NOW.getTime() - 10 * 24 * 60 * 60 * 1000)
+    .toISOString();
+  const getter = (_instance: string) =>
+    Promise.resolve(JSON.stringify({ content: { timestamp: recent } }));
+  const pending = await getPendingQuestions([q], NOW, getter);
+  assertEquals(pending.length, 0);
+});
+
+Deno.test("getPendingQuestions: stale question is pending", async () => {
+  const q = makeQuestion();
+  const old = new Date(NOW.getTime() - 91 * 24 * 60 * 60 * 1000).toISOString();
+  const getter = (_instance: string) =>
+    Promise.resolve(JSON.stringify({ content: { timestamp: old } }));
+  const pending = await getPendingQuestions([q], NOW, getter);
+  assertEquals(pending.length, 1);
+  assertEquals(pending[0].question.question_id, "q-test-001");
+});
+
+Deno.test("getPendingQuestions: never-attested question is pending", async () => {
+  const q = makeQuestion();
+  const getter = (_instance: string): Promise<string | null> =>
+    Promise.resolve(null);
+  const pending = await getPendingQuestions([q], NOW, getter);
+  assertEquals(pending.length, 1);
+  assertEquals(pending[0].lastTimestamp, null);
+});
+
+Deno.test("getPendingQuestions: only stale questions among mixed freshness", async () => {
+  const fresh = makeQuestion({
+    question_id: "q-fresh",
+    instance: "inst-fresh",
+  });
+  const stale = makeQuestion({
+    question_id: "q-stale",
+    instance: "inst-stale",
+  });
+  const recentTs = new Date(NOW.getTime() - 5 * 24 * 60 * 60 * 1000)
+    .toISOString();
+  const oldTs = new Date(NOW.getTime() - 100 * 24 * 60 * 60 * 1000)
+    .toISOString();
+  const getter = (instance: string): Promise<string | null> => {
+    if (instance === "inst-fresh") {
+      return Promise.resolve(
+        JSON.stringify({ content: { timestamp: recentTs } }),
+      );
+    }
+    return Promise.resolve(JSON.stringify({ content: { timestamp: oldTs } }));
+  };
+  const pending = await getPendingQuestions([fresh, stale], NOW, getter);
+  assertEquals(pending.length, 1);
+  assertEquals(pending[0].question.question_id, "q-stale");
+});
+
+Deno.test("getPendingQuestions: uses attributes fallback when content absent", async () => {
+  const q = makeQuestion();
+  const recent = new Date(NOW.getTime() - 5 * 24 * 60 * 60 * 1000)
+    .toISOString();
+  const getter = (_instance: string) =>
+    Promise.resolve(JSON.stringify({ attributes: { timestamp: recent } }));
+  const pending = await getPendingQuestions([q], NOW, getter);
+  assertEquals(pending.length, 0);
+});

--- a/bin/rave-assess.ts
+++ b/bin/rave-assess.ts
@@ -11,6 +11,7 @@ export interface Question {
   descriptor: string;
   instance: string;
   prompt: string;
+  prompt_initial?: string; // used when never attested; falls back to prompt
   answer_type: "yes_no";
   expected_answer: string;
   freshness_window: string; // ISO 8601 duration e.g. P90D
@@ -270,7 +271,9 @@ async function main() {
   if (jsonMode) {
     const out = pending.map((p) => ({
       question_id: p.question.question_id,
-      prompt: p.question.prompt.trim(),
+      prompt: (p.lastTimestamp === null
+        ? (p.question.prompt_initial ?? p.question.prompt)
+        : p.question.prompt).trim(),
       claim_id: p.question.claim_id,
       instance: p.question.instance,
       lastTimestamp: p.lastTimestamp,
@@ -306,7 +309,10 @@ async function main() {
       ? `last attested ${new Date(lastTimestamp).toISOString().slice(0, 10)}`
       : "never attested";
     console.log(`\n[${question.question_id}] (${age})`);
-    console.log(question.prompt.trim());
+    const displayPrompt = (lastTimestamp === null
+      ? (question.prompt_initial ?? question.prompt)
+      : question.prompt).trim();
+    console.log(displayPrompt);
     const answer = prompt("Answer (yes/no): ")?.trim().toLowerCase();
 
     if (answer !== "yes") {
@@ -341,7 +347,9 @@ async function main() {
         const parsed = JSON.parse(result.output);
         const attrs = parsed?.content ?? parsed?.attributes ?? parsed;
         attestedAt = attrs?.attestedAt ?? attrs?.timestamp ?? "";
-      } catch { /* ignore */ }
+      } catch {
+        /* ignore */
+      }
       console.log(
         `  → Declared. attestedAt: ${attestedAt || "(see swamp output)"}`,
       );

--- a/bin/rave-assess.ts
+++ b/bin/rave-assess.ts
@@ -1,0 +1,363 @@
+import { parse as parseYaml } from "jsr:@std/yaml@1";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface Question {
+  question_id: string;
+  claim_id: string;
+  evidence_id: string;
+  descriptor: string;
+  instance: string;
+  prompt: string;
+  answer_type: "yes_no";
+  expected_answer: string;
+  freshness_window: string; // ISO 8601 duration e.g. P90D
+}
+
+export interface DescriptorFile {
+  owner: {
+    name: string;
+    team: string;
+    confirmedAt: string;
+  };
+  dependencies: Array<{
+    name: string;
+    type: string;
+    criticality: string;
+    sla?: string;
+    fallbackPlan?: string;
+  }>;
+  slos: Array<{
+    endpoint: string;
+    target?: number;
+    window?: string;
+  }>;
+}
+
+export interface DeclarePayload {
+  owner: {
+    name: string;
+    team: string;
+    confirmedAt: string;
+  };
+  dependencies: DescriptorFile["dependencies"];
+  slos: DescriptorFile["slos"];
+  attestedBy: string;
+}
+
+export interface PendingQuestion {
+  question: Question;
+  lastTimestamp: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for tests)
+// ---------------------------------------------------------------------------
+
+/** Parse an ISO 8601 duration string (P<n>D only) into milliseconds. */
+export function parseDurationMs(duration: string): number {
+  const match = duration.match(/^P(\d+)D$/);
+  if (match) return parseInt(match[1], 10) * 24 * 60 * 60 * 1000;
+  // Support P<n>M (months, approximate)
+  const mMatch = duration.match(/^P(\d+)M$/);
+  if (mMatch) return parseInt(mMatch[1], 10) * 30 * 24 * 60 * 60 * 1000;
+  // Support P<n>Y
+  const yMatch = duration.match(/^P(\d+)Y$/);
+  if (yMatch) return parseInt(yMatch[1], 10) * 365 * 24 * 60 * 60 * 1000;
+  throw new Error(`Unsupported ISO 8601 duration: ${duration}`);
+}
+
+/** Return true if the given timestamp is older than window from now, or if timestamp is absent. */
+export function isStale(
+  timestamp: string | null | undefined,
+  window: string,
+  now: Date,
+): boolean {
+  if (!timestamp) return true;
+  const t = new Date(timestamp);
+  if (isNaN(t.getTime())) return true;
+  return now.getTime() - t.getTime() > parseDurationMs(window);
+}
+
+/** Load all question YAML files from a directory. */
+export async function loadQuestions(dir: string): Promise<Question[]> {
+  const questions: Question[] = [];
+  for await (const entry of Deno.readDir(dir)) {
+    if (!entry.isFile || !entry.name.endsWith(".yaml")) continue;
+    const text = await Deno.readTextFile(`${dir}/${entry.name}`);
+    const raw = parseYaml(text) as Question;
+    const required: (keyof Question)[] = [
+      "question_id",
+      "claim_id",
+      "evidence_id",
+      "descriptor",
+      "instance",
+      "prompt",
+      "answer_type",
+      "expected_answer",
+      "freshness_window",
+    ];
+    for (const field of required) {
+      if (!raw[field]) {
+        throw new Error(
+          `Question file ${entry.name} is missing required field: ${field}`,
+        );
+      }
+    }
+    questions.push(raw);
+  }
+  questions.sort((a, b) => a.question_id.localeCompare(b.question_id));
+  return questions;
+}
+
+/** Load a descriptor YAML file. */
+export async function loadDescriptor(path: string): Promise<DescriptorFile> {
+  const text = await Deno.readTextFile(path);
+  return parseYaml(text) as DescriptorFile;
+}
+
+/** Build the declare method payload from a descriptor file + answerer. */
+export function buildDeclarePayload(
+  descriptor: DescriptorFile,
+  attestedBy: string,
+): DeclarePayload {
+  return {
+    owner: descriptor.owner,
+    dependencies: descriptor.dependencies,
+    slos: descriptor.slos,
+    attestedBy,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Swamp shell-out (injectable for tests)
+// ---------------------------------------------------------------------------
+
+export type SwampDataGetter = (
+  instance: string,
+) => Promise<string | null>;
+
+export type SwampMethodRunner = (
+  instance: string,
+  payload: DeclarePayload,
+) => Promise<{ success: boolean; output: string }>;
+
+export async function defaultSwampDataGetter(
+  instance: string,
+): Promise<string | null> {
+  try {
+    const cmd = new Deno.Command("swamp", {
+      args: ["data", "get", instance, "current", "--json"],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const out = await cmd.output();
+    if (!out.success) return null;
+    return new TextDecoder().decode(out.stdout);
+  } catch {
+    return null;
+  }
+}
+
+export async function defaultSwampMethodRunner(
+  instance: string,
+  payload: DeclarePayload,
+): Promise<{ success: boolean; output: string }> {
+  const json = JSON.stringify(payload);
+  const cmd = new Deno.Command("swamp", {
+    args: [
+      "model",
+      "method",
+      "run",
+      instance,
+      "declare",
+      "--stdin",
+      "--json",
+    ],
+    stdin: "piped",
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const process = cmd.spawn();
+  const writer = process.stdin.getWriter();
+  await writer.write(new TextEncoder().encode(json));
+  await writer.close();
+  const out = await process.output();
+  return {
+    success: out.success,
+    output: new TextDecoder().decode(out.stdout) +
+      new TextDecoder().decode(out.stderr),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Core assessment logic
+// ---------------------------------------------------------------------------
+
+/** Read the timestamp from a swamp data get response. */
+function extractTimestamp(raw: string | null): string | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    const attrs = parsed?.content ?? parsed?.attributes;
+    return attrs?.timestamp ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Determine which questions are pending (stale or never attested). */
+export async function getPendingQuestions(
+  questions: Question[],
+  now: Date,
+  getSwampData: SwampDataGetter,
+): Promise<PendingQuestion[]> {
+  const pending: PendingQuestion[] = [];
+  for (const q of questions) {
+    const raw = await getSwampData(q.instance);
+    const ts = extractTimestamp(raw);
+    if (isStale(ts, q.freshness_window, now)) {
+      pending.push({ question: q, lastTimestamp: ts });
+    }
+  }
+  return pending;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = new Set(Deno.args);
+  const repoDir = Deno.args.find((a) => !a.startsWith("-")) ?? ".";
+  const jsonMode = args.has("--json");
+
+  const attestedByArg = (() => {
+    const idx = Deno.args.indexOf("--attested-by");
+    if (idx !== -1 && Deno.args[idx + 1]) return Deno.args[idx + 1];
+    return null;
+  })();
+
+  const questionsDir = `${repoDir}/rave/questions`;
+  const descriptorsDir = `${repoDir}/rave/descriptors`;
+
+  let questions: Question[];
+  try {
+    questions = await loadQuestions(questionsDir);
+  } catch (err) {
+    console.error(`Error loading questions from ${questionsDir}: ${err}`);
+    Deno.exit(1);
+  }
+
+  if (questions.length === 0) {
+    if (jsonMode) {
+      console.log(JSON.stringify({ pending: [] }));
+    } else {
+      console.log("No questions found.");
+    }
+    return;
+  }
+
+  const now = new Date();
+  const pending = await getPendingQuestions(
+    questions,
+    now,
+    defaultSwampDataGetter,
+  );
+
+  if (jsonMode) {
+    const out = pending.map((p) => ({
+      question_id: p.question.question_id,
+      prompt: p.question.prompt.trim(),
+      claim_id: p.question.claim_id,
+      instance: p.question.instance,
+      lastTimestamp: p.lastTimestamp,
+    }));
+    console.log(JSON.stringify({ pending: out }, null, 2));
+    return;
+  }
+
+  // Interactive mode — requires a TTY
+  if (!Deno.stdin.isTerminal()) {
+    console.error(
+      "rave-assess: stdin is not a terminal. Use --json to list pending questions without prompting.",
+    );
+    Deno.exit(1);
+  }
+
+  if (pending.length === 0) {
+    console.log("All attestation questions are up to date. Nothing to do.");
+    return;
+  }
+
+  const attestedBy = attestedByArg ??
+    Deno.env.get("USER") ??
+    Deno.env.get("USERNAME") ??
+    "unknown";
+
+  let declared = 0;
+  let skipped = 0;
+  const errors: string[] = [];
+
+  for (const { question, lastTimestamp } of pending) {
+    const age = lastTimestamp
+      ? `last attested ${new Date(lastTimestamp).toISOString().slice(0, 10)}`
+      : "never attested";
+    console.log(`\n[${question.question_id}] (${age})`);
+    console.log(question.prompt.trim());
+    const answer = prompt("Answer (yes/no): ")?.trim().toLowerCase();
+
+    if (answer !== "yes") {
+      console.log("  → Skipped.");
+      skipped++;
+      continue;
+    }
+
+    const descriptorPath = `${descriptorsDir}/${question.descriptor}.yaml`;
+    let descriptor: DescriptorFile;
+    try {
+      descriptor = await loadDescriptor(descriptorPath);
+    } catch (err) {
+      console.error(
+        `  → Error reading descriptor ${descriptorPath}: ${err}`,
+      );
+      errors.push(question.question_id);
+      continue;
+    }
+
+    const payload = buildDeclarePayload(descriptor, attestedBy);
+    console.log(`  → Declaring service descriptor for ${question.instance}…`);
+
+    const result = await defaultSwampMethodRunner(question.instance, payload);
+    if (!result.success) {
+      console.error(`  → Declare failed:\n${result.output}`);
+      errors.push(question.question_id);
+    } else {
+      // Extract attestedAt from the output if possible
+      let attestedAt = "";
+      try {
+        const parsed = JSON.parse(result.output);
+        const attrs = parsed?.content ?? parsed?.attributes ?? parsed;
+        attestedAt = attrs?.attestedAt ?? attrs?.timestamp ?? "";
+      } catch { /* ignore */ }
+      console.log(
+        `  → Declared. attestedAt: ${attestedAt || "(see swamp output)"}`,
+      );
+      declared++;
+    }
+  }
+
+  console.log(
+    `\nDone. Declared: ${declared}, Skipped: ${skipped}, Errors: ${errors.length}`,
+  );
+  if (errors.length > 0) {
+    console.error(`Questions with errors: ${errors.join(", ")}`);
+    Deno.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/deno.json
+++ b/deno.json
@@ -12,6 +12,8 @@
     "dashboard:json": "deno run --allow-read --allow-run=swamp bin/rave-dashboard.ts --json",
     "dashboard:test": "deno test --allow-read --allow-write bin/",
     "cve-scan": "deno run --allow-read --allow-net=api.osv.dev bin/rave-cve-scan.ts",
+    "assess": "deno run --allow-read --allow-run=swamp --allow-env bin/rave-assess.ts",
+    "assess:json": "deno run --allow-read --allow-run=swamp --allow-env bin/rave-assess.ts --json",
     "check": "deno run --allow-read --allow-run=swamp --allow-net=api.osv.dev bin/rave-check.ts"
   },
   "imports": {

--- a/rave/descriptors/rave-swamp.yaml
+++ b/rave/descriptors/rave-swamp.yaml
@@ -1,0 +1,27 @@
+owner:
+  name: Mark Ellens
+  team: RAVE Core
+  confirmedAt: "2026-06-26T00:00:00.000Z"
+
+dependencies:
+  - name: github-actions
+    type: external-api
+    criticality: critical
+    sla: "99.9% uptime per GitHub status page"
+    fallbackPlan: "CI evidence marks inconclusive when unavailable; manual attestation can substitute until restored"
+  - name: swamp-runtime
+    type: service
+    criticality: critical
+    sla: "Self-hosted; maintained by the rave-swamp team"
+    fallbackPlan: "Restore from the latest swamp backup; evidence gathering pauses until runtime is healthy"
+  - name: osv-dev-api
+    type: external-api
+    criticality: standard
+
+slos:
+  - endpoint: "rave-check (readiness gate)"
+    target: 0.95
+    window: "30d"
+  - endpoint: "gather-all-evidence (workflow)"
+    target: 0.9
+    window: "7d"

--- a/rave/questions/q-service-owner-001.yaml
+++ b/rave/questions/q-service-owner-001.yaml
@@ -6,6 +6,9 @@ instance: service-descriptor-rave-swamp-001
 prompt: >
   Is the recorded owner for the service under assessment still accurate
   (correct person and team)?
+prompt_initial: >
+  Who currently owns the service under assessment?
+  Please confirm the owner (person and team) is correctly recorded in the descriptor.
 answer_type: yes_no
 expected_answer: "yes"
 freshness_window: P90D

--- a/rave/questions/q-service-owner-001.yaml
+++ b/rave/questions/q-service-owner-001.yaml
@@ -1,0 +1,11 @@
+question_id: q-service-owner-001
+claim_id: claim-service-owner-current-001
+evidence_id: evidence-service-owner-current-001
+descriptor: rave-swamp
+instance: service-descriptor-rave-swamp-001
+prompt: >
+  Is the recorded owner for the service under assessment still accurate
+  (correct person and team)?
+answer_type: yes_no
+expected_answer: "yes"
+freshness_window: P90D


### PR DESCRIPTION
## Summary

- **`bin/rave-assess.ts`** — questionnaire CLI. `--json` mode lists pending attestation questions without prompting (CI/agent entry point). Interactive TTY mode prompts yes/no and on "yes" reads `rave/descriptors/<descriptor>.yaml` then calls `swamp model method run <instance> declare --stdin` to re-stamp the attestation.
- **`rave/questions/q-service-owner-001.yaml`** — first attestation question: generic "is the recorded owner still accurate?" prompt, P90D freshness window, wired to `service-descriptor-rave-swamp-001`.
- **`rave/descriptors/rave-swamp.yaml`** — git-tracked source of truth for rave-swamp's service descriptor (owner, deps with sla+fallbackPlan for critical ones, SLOs with target+window). Seeded so a `declare` produces `outcome:"pass"` end-to-end.
- **`deno.json`** — adds `assess` and `assess:json` tasks.
- **`bin/rave-assess.test.ts`** — 23 unit tests; all swamp shell-outs stubbed so tests are pure.

Part of epic #88. Closes #90.

## Test plan

- [x] `deno fmt --check bin/rave-assess.ts bin/rave-assess.test.ts` — clean
- [x] `deno lint bin/rave-assess.ts bin/rave-assess.test.ts` — clean
- [x] `deno check bin/rave-assess.ts` — type check passes
- [x] `deno task dashboard:test` — 116 passed, 0 failed
- [x] `deno task assess:json` — lists the ownership question as pending (never attested), exits without prompting
- [ ] End-to-end: run `deno task assess` in a terminal, answer "yes" → verify `swamp data get service-descriptor-rave-swamp-001 current --json` shows a fresh `attestedAt` and `outcome:"pass"` (requires interactive terminal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)