### PR TITLE
M3 (#91): vertical slice A — human-attested claim-service-owner-current-001

### DIFF
--- a/models/@mellens/rave/confidence-engine/e5de49d6-aeac-49c9-a53e-efa3e74e4137.yaml
+++ b/models/@mellens/rave/confidence-engine/e5de49d6-aeac-49c9-a53e-efa3e74e4137.yaml
@@ -1,0 +1,11 @@
+type: '@mellens/rave/confidence-engine'
+typeVersion: 2026.03.21.1
+id: e5de49d6-aeac-49c9-a53e-efa3e74e4137
+name: confidence-claim-service-owner-current-001
+version: 1
+tags: {}
+globalArguments:
+  claimId: claim-service-owner-current-001
+  decayLambda: 0.0028
+  confidenceFloor: 0.01
+methods: {}

--- a/models/@mellens/rave/falsifier-engine/56a69260-c547-4c76-bdff-831fcdf0248b.yaml
+++ b/models/@mellens/rave/falsifier-engine/56a69260-c547-4c76-bdff-831fcdf0248b.yaml
@@ -1,0 +1,11 @@
+type: '@mellens/rave/falsifier-engine'
+typeVersion: 2026.03.21.1
+id: 56a69260-c547-4c76-bdff-831fcdf0248b
+name: falsifier-service-owner-stale-001
+version: 1
+tags: {}
+globalArguments:
+  falsifierId: falsifier-service-owner-stale-001
+  conditionType: staleness
+  condition: '{"max_age":"P90D"}'
+methods: {}

--- a/rave/claims/claim-service-owner-current-001.yaml
+++ b/rave/claims/claim-service-owner-current-001.yaml
@@ -1,0 +1,21 @@
+rave_version: "0.2.0"
+claim_id: claim-service-owner-current-001
+statement: The rave-swamp service has a named owning team confirmed within the last 90 days.
+owner:
+  name: mellens
+  contact: mesgme/rave-swamp
+status: active
+category: ownership
+scope:
+  type: repository
+  target: mesgme/rave-swamp
+assumptions:
+  - Ownership is attested by a human via the rave-assess CLI, which calls rave_service_descriptor.declare
+  - A confirmation within 90 days is sufficient evidence the owner is current
+  - The service descriptor's attestedAt timestamp reflects the most recent human confirmation
+falsification_signals:
+  - The service descriptor has not been re-attested (declare) within the last 90 days
+  - The recorded owner team is removed or left blank in the descriptor
+confidence:
+  decay_lambda: 0.0028
+annotations: []

--- a/rave/evidence/evidence-service-owner-current-001.yaml
+++ b/rave/evidence/evidence-service-owner-current-001.yaml
@@ -1,0 +1,22 @@
+evidence_id: "evidence-service-owner-current-001"
+type: "manual_test"
+description: "Human attestation of rave-swamp service ownership via the rave-assess CLI (drives rave_service_descriptor.declare, which records owner, deps, and SLOs and stamps attestedAt)"
+reference:
+  uri: "swamp://models/service-descriptor-rave-swamp-001/descriptor/current"
+  format: "application/json"
+  authentication:
+    method: "none"
+    hint: "local swamp runtime"
+claim_ids:
+  - "claim-service-owner-current-001"
+freshness_window: "P90D"
+quality_score: 0.90
+methodology:
+  description: "A human runs 'deno task assess', confirms ownership via yes/no prompt, and the CLI calls rave_service_descriptor.declare which writes the descriptor resource with attestedAt = now. The descriptor's timestamp is the evidence timestamp read by the staleness falsifier."
+  tooling: "rave-assess"
+  frequency: "P90D"
+  coverage: "Named owner (person + team) of the rave-swamp service"
+metadata:
+  source_system: "swamp"
+  instance: "service-descriptor-rave-swamp-001"
+  resource: "descriptor"

--- a/rave/falsifiers/falsifier-service-owner-stale-001.yaml
+++ b/rave/falsifiers/falsifier-service-owner-stale-001.yaml
@@ -1,0 +1,14 @@
+falsifier_id: "falsifier-service-owner-stale-001"
+name: "Service Owner Attestation Stale"
+description: "Triggers when the rave-swamp service descriptor has not been re-attested within 90 days, meaning the recorded owner can no longer be assumed current."
+condition:
+  type: "staleness"
+  parameters:
+    max_age: "P90D"
+evidence_ids:
+  - "evidence-service-owner-current-001"
+claim_ids:
+  - "claim-service-owner-current-001"
+metadata:
+  service: "rave-swamp"
+  instance: "service-descriptor-rave-swamp-001"


### PR DESCRIPTION
## Summary

First complete human-attestation loop for epic #88. Depends on #89 (M1) and #90 (M2), both merged.

- **`rave/claims/claim-service-owner-current-001.yaml`** — ownership claim (`category: ownership`, `scope: repository/mesgme/rave-swamp`, `confidence.decay_lambda: 0.0028`). First use of `ownership` category in this repo.
- **`rave/evidence/evidence-service-owner-current-001.yaml`** — `type: manual_test` (first of this type in repo), sourced from `service-descriptor-rave-swamp-001`. `freshness_window: P90D`, `quality_score: 0.90`.
- **`rave/falsifiers/falsifier-service-owner-stale-001.yaml`** — `condition.type: staleness` with `max_age: P90D` (first staleness falsifier in repo). Reads the descriptor's `timestamp` (= `attestedAt`) directly — no `rawData` needed.
- **`confidence-claim-service-owner-current-001` instance** — `decayLambda: 0.0028`, `confidenceFloor: 0.01`.
- **`falsifier-service-owner-stale-001` instance** — `conditionType: staleness`, `condition: '{"max_age":"P90D"}'`.

## Verified

- Falsifier fires (`triggered: true`, detail: "All evidence older than P90D") on 91-day-old evidence ✓
- Falsifier does not fire (`triggered: false`) on fresh evidence ✓
- Confidence decay curve with `C₀=1.0, Q=0.90, λ=0.0028`: 0.90→0.83→0.76→0.72→**0.70 at day 89** — score stays above 0.70 readiness threshold for nearly the full 90-day window ✓
- At day 90 evidence goes stale (`F_avg=0`), score collapses to 0 — consistent with the falsifier firing ✓
- `deno task dashboard:test` — 116/116 passed ✓
- `deno task check` — only pre-existing CVE guidance (yaml@2.8.3, zod@4.3.6 on main too); no new issues ✓

## Out of scope (M5 / #93)

Workflow wiring is hardcoded and deferred: `falsifier-sweep`, `confidence-decay-sweep`, and `readiness-check` will each need one new job/node entry for this claim. Until then, the engines work correctly in isolation via direct method invocation but are not swept automatically.

Closes #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)