### PR TITLE
feat(#92): M4 — swamp-verifiable SLO catalog completeness claim

### DIFF
--- a/models/@mellens/rave/confidence-engine/9e7043a5-85c2-4bfa-8734-2ff33d93ef90.yaml
+++ b/models/@mellens/rave/confidence-engine/9e7043a5-85c2-4bfa-8734-2ff33d93ef90.yaml
@@ -1,0 +1,11 @@
+type: '@mellens/rave/confidence-engine'
+typeVersion: 2026.03.21.1
+id: 9e7043a5-85c2-4bfa-8734-2ff33d93ef90
+name: confidence-claim-slo-catalog-complete-001
+version: 1
+tags: {}
+globalArguments:
+  claimId: claim-slo-catalog-complete-001
+  decayLambda: 0.05
+  confidenceFloor: 0.01
+methods: {}

--- a/models/@mellens/rave/falsifier-engine/b711fa13-c4c7-4661-bab5-7f8fde617fcd.yaml
+++ b/models/@mellens/rave/falsifier-engine/b711fa13-c4c7-4661-bab5-7f8fde617fcd.yaml
@@ -1,0 +1,11 @@
+type: '@mellens/rave/falsifier-engine'
+typeVersion: 2026.03.21.1
+id: b711fa13-c4c7-4661-bab5-7f8fde617fcd
+name: falsifier-slo-incomplete-001
+version: 1
+tags: {}
+globalArguments:
+  falsifierId: falsifier-slo-incomplete-001
+  conditionType: boolean
+  condition: '{"field":"$.sloComplete","expected":true}'
+methods: {}

--- a/rave/claims/claim-slo-catalog-complete-001.yaml
+++ b/rave/claims/claim-slo-catalog-complete-001.yaml
@@ -1,0 +1,21 @@
+rave_version: "0.2.0"
+claim_id: claim-slo-catalog-complete-001
+statement: Every endpoint declared in the rave-swamp service's SLO catalog has both an SLO target and a measurement window.
+owner:
+  name: mellens
+  contact: mesgme/rave-swamp
+status: active
+category: slo
+scope:
+  type: repository
+  target: mesgme/rave-swamp
+assumptions:
+  - The SLO catalog is declared via rave_service_descriptor.declare (driven by the rave-assess CLI)
+  - sloComplete is computed deterministically — true only when no endpoint is missing target or window
+  - A complete catalog is a precondition for meaningful SLO measurement
+falsification_signals:
+  - The descriptor reports sloComplete=false (an endpoint is missing target and/or window)
+  - incompleteEndpoints is non-empty
+confidence:
+  decay_lambda: 0.05
+annotations: []

--- a/rave/evidence/evidence-slo-catalog-complete-001.yaml
+++ b/rave/evidence/evidence-slo-catalog-complete-001.yaml
@@ -1,0 +1,22 @@
+evidence_id: "evidence-slo-catalog-complete-001"
+type: "policy_output"
+description: "Verification that every SLO endpoint declared in the rave-swamp service descriptor has both a numeric target and a measurement window ($.sloComplete=true in descriptor rawData)"
+reference:
+  uri: "swamp://models/service-descriptor-rave-swamp-001/descriptor/current"
+  format: "application/json"
+  authentication:
+    method: "none"
+    hint: "local swamp runtime"
+claim_ids:
+  - "claim-slo-catalog-complete-001"
+freshness_window: "P1D"
+quality_score: 0.90
+methodology:
+  description: "Read the service descriptor resource and verify $.sloComplete is true (every SLO endpoint declares both target and window); incompleteEndpoints enumerates any failures. The descriptor is written by rave_service_descriptor.declare, driven by the rave-assess CLI."
+  tooling: "rave_service_descriptor"
+  frequency: "P1D"
+  coverage: "All SLO endpoints declared in the rave-swamp service descriptor"
+metadata:
+  source_system: "swamp"
+  instance: "service-descriptor-rave-swamp-001"
+  resource: "descriptor"

--- a/rave/falsifiers/falsifier-slo-incomplete-001.yaml
+++ b/rave/falsifiers/falsifier-slo-incomplete-001.yaml
@@ -1,0 +1,15 @@
+falsifier_id: "falsifier-slo-incomplete-001"
+name: "SLO Catalog Incomplete"
+description: "Triggers when the service descriptor reports sloComplete=false, meaning at least one declared SLO endpoint is missing a target or measurement window, contradicting the catalog-complete claim."
+condition:
+  type: "boolean"
+  parameters:
+    field: "$.sloComplete"
+    expected: true
+evidence_ids:
+  - "evidence-slo-catalog-complete-001"
+claim_ids:
+  - "claim-slo-catalog-complete-001"
+metadata:
+  service: "rave-swamp"
+  instance: "service-descriptor-rave-swamp-001"


### PR DESCRIPTION
## Summary

- Adds `claim-slo-catalog-complete-001` (category `slo`, 90-day scope, `decay_lambda: 0.05`) — asserts every SLO endpoint in the service descriptor declares both a target and a measurement window.
- Adds `evidence-slo-catalog-complete-001` (`type: policy_output`, `freshness_window: P1D`, `quality_score: 0.90`) — sourced from the descriptor's `rawData` via `$.sloComplete`.
- Adds `falsifier-slo-incomplete-001` (boolean condition on `$.sloComplete`, `expected: true`) — fires when the descriptor reports `sloComplete: false`.
- Registers two swamp engine instances: `confidence-claim-slo-catalog-complete-001` (λ=0.05) and `falsifier-slo-incomplete-001` (boolean).

No new question file, model change, or descriptor change — the existing `rave-assess` → `declare` flow already writes `sloComplete` into `rawData`. This is the companion to M3 (staleness falsifier): M4 proves the machinery can **mechanically** falsify a claim from computed descriptor data.

This is M4 of epic #88. Closes #92.

## Verification

All verification steps passed in the `../rave-swamp-m4` worktree:

- **116 tests, 0 failed** (`deno task dashboard:test`) — including `parseClaimFiles loads all rave/claims/*.yaml` confirming the new claim parses cleanly.
- **Boolean falsifier fires** (`sloComplete: false`, `incompleteEndpoints: ["checkout (api)"]`) → `triggered: true`, `detail: "$.sloComplete = false, expected true (triggered)"`.
- **Boolean falsifier does not fire** (`sloComplete: true`) → `triggered: false`.
- **Confidence engine** → `confidenceScore: 0.90` (Q_avg=0.90, F_avg=1.0, Δt≈0, well above 0.70).
- `deno fmt --check`, `deno lint`, `deno check` all clean.

## Back-pressure note

`deno task check` exits non-zero — all existing claims score 0 because no confidence-decay-sweep has run in this fresh worktree (identical state to M3 in PR #97). The new `claim-slo-catalog-complete-001` likewise has no swept score; `claim-no-known-cves-001` shows guidance for `yaml@2.8.3` / `zod@4.3.6` which are pre-existing findings, not introduced by M4. Sweep wiring for both claims is M5 (#93).

## Guarded paths

Modifies `rave/claims/**` and `rave/falsifiers/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)