### PR TITLE
feat(#93): M5 — wire M3/M4 claims into sweep + readiness workflows

### DIFF
--- a/workflows/workflow-2da6b960-0b08-494b-95b6-6b21ee8f7e25.yaml
+++ b/workflows/workflow-2da6b960-0b08-494b-95b6-6b21ee8f7e25.yaml
@@ -304,3 +304,43 @@ jobs:
                 freshnessWindow: "P1D"
                 value: null
                 rawData: null
+  - name: service-owner-stale
+    description: Evaluate falsifier-service-owner-stale-001 against the service descriptor attestation timestamp
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: evaluate
+        description: Check whether the service descriptor has been re-attested within 90 days
+        allowFailure: true
+        task:
+          type: model_method
+          modelIdOrName: falsifier-service-owner-stale-001
+          methodName: evaluate
+          inputs:
+            evidence:
+              - evidenceId: "evidence-service-owner-current-001"
+                outcome: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.timestamp }}
+                freshnessWindow: "P90D"
+                value: null
+                rawData: null
+  - name: slo-incomplete
+    description: Evaluate falsifier-slo-incomplete-001 against the service descriptor SLO completeness
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: evaluate
+        description: Check whether every declared SLO endpoint has a target and window ($.sloComplete)
+        allowFailure: true
+        task:
+          type: model_method
+          modelIdOrName: falsifier-slo-incomplete-001
+          methodName: evaluate
+          inputs:
+            evidence:
+              - evidenceId: "evidence-slo-catalog-complete-001"
+                outcome: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.timestamp }}
+                freshnessWindow: "P1D"
+                value: null
+                rawData: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.rawData }}

--- a/workflows/workflow-adfc9a4a-a667-4f4f-8f98-7d9edee3893d.yaml
+++ b/workflows/workflow-adfc9a4a-a667-4f4f-8f98-7d9edee3893d.yaml
@@ -105,3 +105,11 @@ jobs:
                 nodeType: "claim"
                 status: "active"
                 confidenceScore: ${{ data.latest("confidence-claim-unit-tests-pass-001", "current").attributes.confidenceScore }}
+              - nodeId: "claim-service-owner-current-001"
+                nodeType: "claim"
+                status: "active"
+                confidenceScore: ${{ data.latest("confidence-claim-service-owner-current-001", "current").attributes.confidenceScore }}
+              - nodeId: "claim-slo-catalog-complete-001"
+                nodeType: "claim"
+                status: "active"
+                confidenceScore: ${{ data.latest("confidence-claim-slo-catalog-complete-001", "current").attributes.confidenceScore }}

--- a/workflows/workflow-fd0aacde-a1bc-46d1-bd64-3b1a8c239263.yaml
+++ b/workflows/workflow-fd0aacde-a1bc-46d1-bd64-3b1a8c239263.yaml
@@ -363,3 +363,47 @@ jobs:
                 qualityScore: 0.95
                 failureReason: ${{ data.latest("evidence-rave-spec-untampered-001", "current").attributes.failureReason }}
                 remediation: ${{ data.latest("evidence-rave-spec-untampered-001", "current").attributes.remediation }}
+  - name: service-owner-current
+    description: Recompute confidence for claim-service-owner-current-001
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: compute
+        description: Apply RAVE decay formula with latest service descriptor attestation
+        allowFailure: true
+        task:
+          type: model_method
+          modelIdOrName: confidence-claim-service-owner-current-001
+          methodName: compute
+          inputs:
+            currentStatus: "active"
+            evidence:
+              - evidenceId: "evidence-service-owner-current-001"
+                outcome: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.timestamp }}
+                freshnessWindow: "P90D"
+                qualityScore: 0.90
+                failureReason: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.remediation }}
+  - name: slo-catalog-complete
+    description: Recompute confidence for claim-slo-catalog-complete-001
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: compute
+        description: Apply RAVE decay formula with latest SLO completeness evidence
+        allowFailure: true
+        task:
+          type: model_method
+          modelIdOrName: confidence-claim-slo-catalog-complete-001
+          methodName: compute
+          inputs:
+            currentStatus: "active"
+            evidence:
+              - evidenceId: "evidence-slo-catalog-complete-001"
+                outcome: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.timestamp }}
+                freshnessWindow: "P1D"
+                qualityScore: 0.90
+                failureReason: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.remediation }}


### PR DESCRIPTION
## Summary

Wires the two new epic #88 claims into the existing scheduled sweep pipelines, completing the milestone chain M1→M5.

- **`falsifier-sweep`** (`workflow-2da6b960-….yaml`): +2 jobs — `service-owner-stale` (staleness on `service-descriptor-rave-swamp-001`/timestamp) and `slo-incomplete` (boolean on `service-descriptor-rave-swamp-001`/rawData `$.sloComplete`).
- **`confidence-decay-sweep`** (`workflow-fd0aacde-….yaml`): +2 jobs — `service-owner-current` (freshness P90D, quality 0.90) and `slo-catalog-complete` (freshness P1D, quality 0.90).
- **`readiness-check`** (`workflow-adfc9a4a-….yaml`): +2 nodes referencing `confidence-claim-service-owner-current-001` and `confidence-claim-slo-catalog-complete-001`.
- **`gather-all-evidence`**: **no change** — descriptor evidence is written out-of-band by `rave_service_descriptor.declare` (driven by `deno task assess`); the sweep reads whatever is already there.

Closes #93.

## Issue reconciliation

#93's body assumed a `rave_slo_evidence gather` model existed — it doesn't. Both the ownership evidence and the SLO evidence source from the **same** `service-descriptor-rave-swamp-001 / current` resource, so no new gather job is needed.

## Verification

All run in the `../rave-swamp-m5` worktree after seeding a fresh attestation (`declare` with complete descriptor):

- **`swamp workflow validate`** — 6/6 workflows PASSED (all new jobs validated — schema, unique names, step inputs, GlobalArgument references).
- **`deno task dashboard:test`** — 116/116 passed, 0 failed (no code changes).
- **`confidence-decay-sweep`**: `service-owner-current` and `slo-catalog-complete` jobs both `status=succeeded`; scores `0.81` each (≥ 0.70 threshold). ✅
- **`falsifier-sweep`**: `service-owner-stale` — `triggered: false` ("Evidence within staleness window P90D"); `slo-incomplete` — `triggered: false` ("$.sloComplete matches expected value true"). ✅
- **`deno task check`**: both new claims score 0.81 and are **absent from the failing list** (passing). The 17 CI/governance claims score 0 (expected: no `gather-all-evidence` run in a fresh checkout — same as M3/M4 PRs). Overall exit is non-zero due to those pre-existing zeros.

## Known limitations (noted in PR for visibility)

- **Shared descriptor `outcome`** couples the two new claims' `F_avg` — descriptor emits a single `outcome: pass` only when both `criticalDepsDocumented` AND `sloComplete` hold. Falsifiers are correctly scoped (staleness vs. boolean). Future refinement: per-claim outcomes (relates to #32).
- **SLO claim steady-state freshness**: `P1D` freshness + P90D attestation cadence means SLO confidence goes stale ~1 day after `declare` unless re-verified. Immediate post-declare score is ≥ 0.70 as required; recurring verification is future work (#32).

## Guarded paths

Modifies `workflows/workflow-*.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)