### PR TITLE
feat: implement four Fowler claims (dependencies, health, deprecation, clients)

### DIFF
--- a/docs/production-readiness-claims-todo.md
+++ b/docs/production-readiness-claims-todo.md
@@ -71,21 +71,24 @@ tested code, and a fully automated build and deployment pipeline.*
   - **Evidence idea:** Deployment / canary-analysis result (Argo Rollouts analysis run, or deploy-tool API).
   - **Falsifier idea:** boolean — latest canary analysis verdict == `pass`.
 
-- [ ] `claim-clients-known-001` — **stability** — All upstream clients of `<service>` are catalogued and accessible to the service team.
+- [x] `claim-clients-known-001` — **stability** — All upstream clients of `<service>` are catalogued and accessible to the service team.
   - **Evidence idea:** Service-graph API / API gateway consumer registry.
   - **Falsifier idea:** staleness — client inventory refreshed within window (e.g. `P30D`).
+  - ✅ **rave-swamp:** `claim-clients-known-001`
 
-- [ ] `claim-dependencies-known-001` — **stability** — All downstream dependencies of `<service>` are catalogued (synchronous and asynchronous).
+- [x] `claim-dependencies-known-001` — **stability** — All downstream dependencies of `<service>` are catalogued (synchronous and asynchronous).
   - **Evidence idea:** Dependency manifest (`package.json`, lock file) + service-mesh topology / registry.
   - **Falsifier idea:** staleness — dependency inventory record fresh within window.
+  - ✅ **rave-swamp:** `claim-dependencies-known-001`
 
 - [ ] `claim-dependency-fallbacks-001` — **fault_tolerance** — Each critical dependency of `<service>` has a defined fallback (cache, retry with backoff, circuit breaker, or graceful degradation).
   - **Evidence idea:** Resilience-config audit (e.g. Resilience4j config, policy-as-code output).
   - **Falsifier idea:** boolean — every critical dependency entry carries a declared fallback strategy.
 
-- [ ] `claim-health-checks-present-001` — **reliability** — `<service>` exposes liveness and readiness health checks that are configured and honoured by the deployment platform.
+- [x] `claim-health-checks-present-001` — **reliability** — `<service>` exposes liveness and readiness health checks that are configured and honoured by the deployment platform.
   - **Evidence idea:** Orchestrator probe config (Kubernetes pod spec `livenessProbe` / `readinessProbe`) + last health-check result.
   - **Falsifier idea:** boolean — both probes are configured and last result is healthy.
+  - ✅ **rave-swamp:** `claim-health-checks-present-001` (adapted: CI validation pipeline presence as health signal)
 
 - [ ] `claim-service-discovery-routed-001` — **reliability** — Traffic reaches `<service>` exclusively via service discovery or a stable virtual endpoint; no hardcoded IP/host references exist in clients.
   - **Evidence idea:** Service registry entry + mesh/gateway routing config audit.
@@ -94,6 +97,7 @@ tested code, and a fully automated build and deployment pipeline.*
 - [ ] `claim-deprecation-procedure-001` — **stability** — A documented deprecation and decommission procedure exists for `<service>` and has been reviewed recently.
   - **Evidence idea:** Runbook / ops doc presence check + `last_reviewed` metadata.
   - **Falsifier idea:** staleness — procedure doc reviewed within window (e.g. `P180D`).
+  - ⏸ **rave-swamp:** `claim-deprecation-procedure-001` (draft — procedure doc needed before activating)
 
 ---
 
@@ -309,13 +313,13 @@ owner, and has been formally assessed for production readiness.*
 
 | Section | Total | Done (`[x]`) | Remaining (`[ ]`) |
 |---------|-------|--------------|-------------------|
-| 1. Stability & Reliability | 11 | 3 | 8 |
+| 1. Stability & Reliability | 11 | 6 | 5 |
 | 2. Scalability & Performance | 11 | 0 | 11 |
 | 3. Fault Tolerance & Catastrophe-Preparedness | 6 | 0 | 6 |
 | 4. Monitoring | 6 | 0 | 6 |
 | 5. Documentation & Understanding | 5 | 1 | 4 |
 | 6. Modern / AI-era additions | 11 | 3 | 8 |
-| **Total** | **50** | **7** | **43** |
+| **Total** | **50** | **10** | **40** |
 
 ---
 

--- a/models/@mellens/rave/confidence-engine/199087ed-03c8-42c4-b7d6-893fc6116762.yaml
+++ b/models/@mellens/rave/confidence-engine/199087ed-03c8-42c4-b7d6-893fc6116762.yaml
@@ -1,0 +1,11 @@
+type: '@mellens/rave/confidence-engine'
+typeVersion: 2026.03.21.1
+id: 199087ed-03c8-42c4-b7d6-893fc6116762
+name: confidence-claim-clients-known-001
+version: 1
+tags: {}
+globalArguments:
+  claimId: claim-clients-known-001
+  decayLambda: 0.0028
+  confidenceFloor: 0.01
+methods: {}

--- a/models/@mellens/rave/confidence-engine/1dda64c5-2694-41f9-987a-5cc15606e0b3.yaml
+++ b/models/@mellens/rave/confidence-engine/1dda64c5-2694-41f9-987a-5cc15606e0b3.yaml
@@ -1,0 +1,11 @@
+type: '@mellens/rave/confidence-engine'
+typeVersion: 2026.03.21.1
+id: 1dda64c5-2694-41f9-987a-5cc15606e0b3
+name: confidence-claim-deprecation-procedure-001
+version: 1
+tags: {}
+globalArguments:
+  claimId: claim-deprecation-procedure-001
+  decayLambda: 0.0028
+  confidenceFloor: 0.01
+methods: {}

--- a/models/@mellens/rave/confidence-engine/74e7f174-78bb-48b8-a2e1-65eb88d6f190.yaml
+++ b/models/@mellens/rave/confidence-engine/74e7f174-78bb-48b8-a2e1-65eb88d6f190.yaml
@@ -1,0 +1,11 @@
+type: '@mellens/rave/confidence-engine'
+typeVersion: 2026.03.21.1
+id: 74e7f174-78bb-48b8-a2e1-65eb88d6f190
+name: confidence-claim-dependencies-known-001
+version: 1
+tags: {}
+globalArguments:
+  claimId: claim-dependencies-known-001
+  decayLambda: 0.0028
+  confidenceFloor: 0.01
+methods: {}

--- a/models/@mellens/rave/confidence-engine/b1fb36dd-2a04-4afb-bf70-4b35a4cfdfbc.yaml
+++ b/models/@mellens/rave/confidence-engine/b1fb36dd-2a04-4afb-bf70-4b35a4cfdfbc.yaml
@@ -1,0 +1,11 @@
+type: '@mellens/rave/confidence-engine'
+typeVersion: 2026.03.21.1
+id: b1fb36dd-2a04-4afb-bf70-4b35a4cfdfbc
+name: confidence-claim-health-checks-present-001
+version: 1
+tags: {}
+globalArguments:
+  claimId: claim-health-checks-present-001
+  decayLambda: 0.05
+  confidenceFloor: 0.01
+methods: {}

--- a/models/@mellens/rave/falsifier-engine/4201ed57-005c-4956-91f0-4449db50794d.yaml
+++ b/models/@mellens/rave/falsifier-engine/4201ed57-005c-4956-91f0-4449db50794d.yaml
@@ -1,0 +1,11 @@
+type: '@mellens/rave/falsifier-engine'
+typeVersion: 2026.03.21.1
+id: 4201ed57-005c-4956-91f0-4449db50794d
+name: falsifier-clients-unknown-001
+version: 1
+tags: {}
+globalArguments:
+  falsifierId: falsifier-clients-unknown-001
+  conditionType: staleness
+  condition: '{"max_age":"P90D"}'
+methods: {}

--- a/models/@mellens/rave/falsifier-engine/5942e057-8d1c-4c67-bd3e-4994e3b3448b.yaml
+++ b/models/@mellens/rave/falsifier-engine/5942e057-8d1c-4c67-bd3e-4994e3b3448b.yaml
@@ -1,0 +1,11 @@
+type: '@mellens/rave/falsifier-engine'
+typeVersion: 2026.03.21.1
+id: 5942e057-8d1c-4c67-bd3e-4994e3b3448b
+name: falsifier-health-checks-absent-001
+version: 1
+tags: {}
+globalArguments:
+  falsifierId: falsifier-health-checks-absent-001
+  conditionType: boolean
+  condition: '{"field":"$.name","expected":"validate.yml"}'
+methods: {}

--- a/models/@mellens/rave/falsifier-engine/6be22b78-ada5-487e-85a8-4e603c323a73.yaml
+++ b/models/@mellens/rave/falsifier-engine/6be22b78-ada5-487e-85a8-4e603c323a73.yaml
@@ -1,0 +1,11 @@
+type: '@mellens/rave/falsifier-engine'
+typeVersion: 2026.03.21.1
+id: 6be22b78-ada5-487e-85a8-4e603c323a73
+name: falsifier-deprecation-procedure-stale-001
+version: 1
+tags: {}
+globalArguments:
+  falsifierId: falsifier-deprecation-procedure-stale-001
+  conditionType: staleness
+  condition: '{"max_age":"P180D"}'
+methods: {}

--- a/models/@mellens/rave/falsifier-engine/f6ae0831-d590-4441-bc54-0324384a77ad.yaml
+++ b/models/@mellens/rave/falsifier-engine/f6ae0831-d590-4441-bc54-0324384a77ad.yaml
@@ -1,0 +1,11 @@
+type: '@mellens/rave/falsifier-engine'
+typeVersion: 2026.03.21.1
+id: f6ae0831-d590-4441-bc54-0324384a77ad
+name: falsifier-dependencies-unknown-001
+version: 1
+tags: {}
+globalArguments:
+  falsifierId: falsifier-dependencies-unknown-001
+  conditionType: staleness
+  condition: '{"max_age":"P90D"}'
+methods: {}

--- a/models/@mellens/rave/github-api-evidence/0afceb28-119a-4a3e-8396-30b744557f6a.yaml
+++ b/models/@mellens/rave/github-api-evidence/0afceb28-119a-4a3e-8396-30b744557f6a.yaml
@@ -1,0 +1,12 @@
+type: "@mellens/rave/github-api-evidence"
+typeVersion: 2026.03.22.1
+id: 0afceb28-119a-4a3e-8396-30b744557f6a
+name: evidence-health-checks-present-001
+version: 1
+tags: {}
+globalArguments:
+  evidenceId: evidence-health-checks-present-001
+  repo: mesgme/rave-swamp
+  endpoint: /contents/.github/workflows/validate.yml
+  successField: $.name
+methods: {}

--- a/rave/claims/claim-clients-known-001.yaml
+++ b/rave/claims/claim-clients-known-001.yaml
@@ -1,0 +1,21 @@
+rave_version: "0.2.0"
+claim_id: claim-clients-known-001
+statement: All known upstream users and adopters of rave-swamp are catalogued, or it is explicitly confirmed that no external clients currently exist.
+owner:
+  name: mellens
+  contact: mesgme/rave-swamp
+status: active
+category: stability
+scope:
+  type: repository
+  target: mesgme/rave-swamp
+assumptions:
+  - The team is aware of all known adopters through direct contact, GitHub stars/forks, or issue activity
+  - Confirming "no external clients" is a valid attestation for an early-stage open-source tool
+  - The service descriptor attestation is the mechanism by which client knowledge is confirmed
+falsification_signals:
+  - A new adopter is discovered who is not in the known client list and was not previously confirmed as "no external clients"
+  - The descriptor has not been re-attested within 90 days
+confidence:
+  decay_lambda: 0.0028
+annotations: []

--- a/rave/claims/claim-dependencies-known-001.yaml
+++ b/rave/claims/claim-dependencies-known-001.yaml
@@ -1,0 +1,22 @@
+rave_version: "0.2.0"
+claim_id: claim-dependencies-known-001
+statement: All critical dependencies of rave-swamp are catalogued with their type, criticality, SLA, and fallback plan.
+owner:
+  name: mellens
+  contact: mesgme/rave-swamp
+status: active
+category: stability
+scope:
+  type: repository
+  target: mesgme/rave-swamp
+assumptions:
+  - All dependencies are documented in rave/descriptors/rave-swamp.yaml under the dependencies key
+  - The service descriptor is re-attested via deno task assess at least every 90 days
+  - A dependency is "critical" if service degradation or outage follows from its unavailability
+falsification_signals:
+  - A new critical dependency is integrated but not added to the descriptor within the attestation window
+  - The service descriptor has not been re-attested within 90 days
+  - A dependency entry is missing its criticality, SLA, or fallbackPlan field
+confidence:
+  decay_lambda: 0.0028
+annotations: []

--- a/rave/claims/claim-deprecation-procedure-001.yaml
+++ b/rave/claims/claim-deprecation-procedure-001.yaml
@@ -1,0 +1,22 @@
+rave_version: "0.2.0"
+claim_id: claim-deprecation-procedure-001
+statement: A documented deprecation and decommission procedure exists for rave-swamp and has been reviewed within the past 180 days.
+owner:
+  name: mellens
+  contact: mesgme/rave-swamp
+status: draft
+category: stability
+scope:
+  type: repository
+  target: mesgme/rave-swamp
+assumptions:
+  - A deprecation procedure is documented in the repository (e.g. CONTRIBUTING.md or a dedicated doc)
+  - The procedure covers how to deprecate extension models, workflows, and the repo itself
+  - Human re-attestation via deno task assess is sufficient to confirm the procedure remains current
+falsification_signals:
+  - No deprecation or decommission procedure is documented in the repository
+  - The documented procedure has not been reviewed within 180 days
+confidence:
+  decay_lambda: 0.0028
+annotations:
+  - "Draft: a deprecation procedure doc must be written before this claim can be activated."

--- a/rave/claims/claim-health-checks-present-001.yaml
+++ b/rave/claims/claim-health-checks-present-001.yaml
@@ -1,0 +1,21 @@
+rave_version: "0.2.0"
+claim_id: claim-health-checks-present-001
+statement: The rave-swamp CI validation pipeline is configured and present in the repository, providing a machine-callable operational health signal for the service.
+owner:
+  name: mellens
+  contact: mesgme/rave-swamp
+status: active
+category: reliability
+scope:
+  type: repository
+  target: mesgme/rave-swamp
+assumptions:
+  - For a CLI/automation repo, the CI validation workflow (validate.yml) is the functional equivalent of a service health check
+  - The workflow runs on every push to main and on every pull request
+  - Absence of the workflow file indicates the health signal has been removed or broken
+falsification_signals:
+  - .github/workflows/validate.yml is absent from the repository
+  - The CI validation workflow is disabled or deleted
+confidence:
+  decay_lambda: 0.05
+annotations: []

--- a/rave/evidence/evidence-clients-known-001.yaml
+++ b/rave/evidence/evidence-clients-known-001.yaml
@@ -1,0 +1,22 @@
+evidence_id: "evidence-clients-known-001"
+type: "manual_test"
+description: "Human attestation via deno task assess that all known upstream users of rave-swamp are catalogued, or that no external clients currently exist"
+reference:
+  uri: "swamp://models/service-descriptor-rave-swamp-001/descriptor/current"
+  format: "application/json"
+  authentication:
+    method: "none"
+    hint: "local swamp runtime"
+claim_ids:
+  - "claim-clients-known-001"
+freshness_window: "P90D"
+quality_score: 0.85
+methodology:
+  description: "A human runs 'deno task assess', confirms the known client/adopter list is complete (or confirms no external clients exist) via yes/no prompt, and the CLI calls rave_service_descriptor.declare which stamps attestedAt = now."
+  tooling: "rave-assess"
+  frequency: "P90D"
+  coverage: "All known upstream adopters of the rave-swamp project"
+metadata:
+  source_system: "swamp"
+  instance: "service-descriptor-rave-swamp-001"
+  resource: "descriptor"

--- a/rave/evidence/evidence-dependencies-known-001.yaml
+++ b/rave/evidence/evidence-dependencies-known-001.yaml
@@ -1,0 +1,22 @@
+evidence_id: "evidence-dependencies-known-001"
+type: "manual_test"
+description: "Human attestation via deno task assess that the dependency list in rave/descriptors/rave-swamp.yaml is complete (all critical deps documented with type, criticality, SLA, and fallback plan)"
+reference:
+  uri: "swamp://models/service-descriptor-rave-swamp-001/descriptor/current"
+  format: "application/json"
+  authentication:
+    method: "none"
+    hint: "local swamp runtime"
+claim_ids:
+  - "claim-dependencies-known-001"
+freshness_window: "P90D"
+quality_score: 0.85
+methodology:
+  description: "A human runs 'deno task assess', confirms the dependency list is complete and current via yes/no prompt, and the CLI calls rave_service_descriptor.declare which stamps attestedAt = now. The staleness falsifier checks this timestamp."
+  tooling: "rave-assess"
+  frequency: "P90D"
+  coverage: "All critical dependencies of the rave-swamp service catalogued in rave/descriptors/rave-swamp.yaml"
+metadata:
+  source_system: "swamp"
+  instance: "service-descriptor-rave-swamp-001"
+  resource: "descriptor"

--- a/rave/evidence/evidence-deprecation-procedure-001.yaml
+++ b/rave/evidence/evidence-deprecation-procedure-001.yaml
@@ -1,0 +1,22 @@
+evidence_id: "evidence-deprecation-procedure-001"
+type: "manual_test"
+description: "Human attestation via deno task assess that a deprecation and decommission procedure exists for rave-swamp and has been reviewed recently"
+reference:
+  uri: "swamp://models/service-descriptor-rave-swamp-001/descriptor/current"
+  format: "application/json"
+  authentication:
+    method: "none"
+    hint: "local swamp runtime"
+claim_ids:
+  - "claim-deprecation-procedure-001"
+freshness_window: "P180D"
+quality_score: 0.80
+methodology:
+  description: "A human runs 'deno task assess', confirms a deprecation/decommission procedure exists and is current via yes/no prompt, and the CLI calls rave_service_descriptor.declare which stamps attestedAt = now."
+  tooling: "rave-assess"
+  frequency: "P180D"
+  coverage: "Existence and currency of the rave-swamp deprecation/decommission procedure"
+metadata:
+  source_system: "swamp"
+  instance: "service-descriptor-rave-swamp-001"
+  resource: "descriptor"

--- a/rave/evidence/evidence-health-checks-present-001.yaml
+++ b/rave/evidence/evidence-health-checks-present-001.yaml
@@ -1,0 +1,22 @@
+evidence_id: "evidence-health-checks-present-001"
+type: "api"
+description: "GitHub API check that .github/workflows/validate.yml exists in the repository, confirming the CI validation pipeline (rave-swamp's operational health signal) is present"
+reference:
+  uri: "https://api.github.com/repos/mesgme/rave-swamp/contents/.github/workflows/validate.yml"
+  format: "application/json"
+  authentication:
+    method: "bearer"
+    hint: "vault.get(rave-credentials, GITHUB_TOKEN)"
+claim_ids:
+  - "claim-health-checks-present-001"
+freshness_window: "P1D"
+quality_score: 0.90
+methodology:
+  description: "Query the GitHub Contents API for the validate.yml file. A 200 response with name='validate.yml' confirms the CI health pipeline is present. A 404 returns inconclusive."
+  tooling: "rave_github_api_evidence"
+  frequency: "P1D"
+  coverage: "Presence of the primary CI validation workflow file"
+metadata:
+  source_system: "github"
+  instance: "evidence-health-checks-present-001"
+  resource: "result"

--- a/rave/falsifiers/falsifier-clients-unknown-001.yaml
+++ b/rave/falsifiers/falsifier-clients-unknown-001.yaml
@@ -1,0 +1,14 @@
+falsifier_id: "falsifier-clients-unknown-001"
+name: "Client Catalog Stale"
+description: "Triggers when the rave-swamp client/adopter list has not been human-confirmed within 90 days, meaning the known clients can no longer be assumed current."
+condition:
+  type: "staleness"
+  parameters:
+    max_age: "P90D"
+evidence_ids:
+  - "evidence-clients-known-001"
+claim_ids:
+  - "claim-clients-known-001"
+metadata:
+  service: "rave-swamp"
+  instance: "service-descriptor-rave-swamp-001"

--- a/rave/falsifiers/falsifier-dependencies-unknown-001.yaml
+++ b/rave/falsifiers/falsifier-dependencies-unknown-001.yaml
@@ -1,0 +1,14 @@
+falsifier_id: "falsifier-dependencies-unknown-001"
+name: "Dependency Catalog Stale"
+description: "Triggers when the rave-swamp dependency record has not been human-confirmed within 90 days, meaning the catalogued dependencies can no longer be assumed complete and current."
+condition:
+  type: "staleness"
+  parameters:
+    max_age: "P90D"
+evidence_ids:
+  - "evidence-dependencies-known-001"
+claim_ids:
+  - "claim-dependencies-known-001"
+metadata:
+  service: "rave-swamp"
+  instance: "service-descriptor-rave-swamp-001"

--- a/rave/falsifiers/falsifier-deprecation-procedure-stale-001.yaml
+++ b/rave/falsifiers/falsifier-deprecation-procedure-stale-001.yaml
@@ -1,0 +1,14 @@
+falsifier_id: "falsifier-deprecation-procedure-stale-001"
+name: "Deprecation Procedure Stale"
+description: "Triggers when the rave-swamp deprecation/decommission procedure has not been human-confirmed within 180 days, or has never been attested."
+condition:
+  type: "staleness"
+  parameters:
+    max_age: "P180D"
+evidence_ids:
+  - "evidence-deprecation-procedure-001"
+claim_ids:
+  - "claim-deprecation-procedure-001"
+metadata:
+  service: "rave-swamp"
+  instance: "service-descriptor-rave-swamp-001"

--- a/rave/falsifiers/falsifier-health-checks-absent-001.yaml
+++ b/rave/falsifiers/falsifier-health-checks-absent-001.yaml
@@ -1,0 +1,15 @@
+falsifier_id: "falsifier-health-checks-absent-001"
+name: "CI Health Pipeline Absent"
+description: "Triggers when .github/workflows/validate.yml is absent from the repository, meaning the primary operational health signal for rave-swamp has been removed."
+condition:
+  type: "boolean"
+  parameters:
+    field: "$.name"
+    expected: "validate.yml"
+evidence_ids:
+  - "evidence-health-checks-present-001"
+claim_ids:
+  - "claim-health-checks-present-001"
+metadata:
+  service: "rave-swamp"
+  instance: "evidence-health-checks-present-001"

--- a/rave/questions/q-clients-known-001.yaml
+++ b/rave/questions/q-clients-known-001.yaml
@@ -1,0 +1,15 @@
+question_id: q-clients-known-001
+claim_id: claim-clients-known-001
+evidence_id: evidence-clients-known-001
+descriptor: rave-swamp
+instance: service-descriptor-rave-swamp-001
+prompt: >
+  Are all known upstream users and adopters of rave-swamp catalogued,
+  or is it confirmed that no external clients currently exist?
+prompt_initial: >
+  Please check for any known adopters of rave-swamp (GitHub forks, stars, issue reporters
+  using it in production, or direct contacts). Confirm either that all known clients
+  are catalogued, or that no external clients currently exist.
+answer_type: yes_no
+expected_answer: "yes"
+freshness_window: P90D

--- a/rave/questions/q-dependencies-known-001.yaml
+++ b/rave/questions/q-dependencies-known-001.yaml
@@ -1,0 +1,15 @@
+question_id: q-dependencies-known-001
+claim_id: claim-dependencies-known-001
+evidence_id: evidence-dependencies-known-001
+descriptor: rave-swamp
+instance: service-descriptor-rave-swamp-001
+prompt: >
+  Is the dependency list in rave/descriptors/rave-swamp.yaml complete and current
+  (all critical dependencies documented with name, type, criticality, SLA, and fallback plan)?
+prompt_initial: >
+  Please review rave/descriptors/rave-swamp.yaml and confirm the dependencies section
+  is complete: every critical dependency should have name, type, criticality, an SLA
+  statement, and a fallbackPlan. Add any missing dependencies before confirming.
+answer_type: yes_no
+expected_answer: "yes"
+freshness_window: P90D

--- a/rave/questions/q-deprecation-procedure-001.yaml
+++ b/rave/questions/q-deprecation-procedure-001.yaml
@@ -1,0 +1,15 @@
+question_id: q-deprecation-procedure-001
+claim_id: claim-deprecation-procedure-001
+evidence_id: evidence-deprecation-procedure-001
+descriptor: rave-swamp
+instance: service-descriptor-rave-swamp-001
+prompt: >
+  Is the deprecation and decommission procedure for rave-swamp still current
+  and documented in the repository?
+prompt_initial: >
+  Does a deprecation and decommission procedure exist for rave-swamp?
+  It should cover how to deprecate extension models, workflows, and the repo itself
+  (e.g. in CONTRIBUTING.md or a dedicated doc). Confirm it exists and is current.
+answer_type: yes_no
+expected_answer: "yes"
+freshness_window: P180D

--- a/workflows/workflow-2da6b960-0b08-494b-95b6-6b21ee8f7e25.yaml
+++ b/workflows/workflow-2da6b960-0b08-494b-95b6-6b21ee8f7e25.yaml
@@ -344,3 +344,63 @@ jobs:
                 freshnessWindow: "P1D"
                 value: null
                 rawData: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.rawData }}
+  - name: dependencies-unknown
+    description: Evaluate falsifier-dependencies-unknown-001 against the service descriptor attestation timestamp
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: evaluate
+        description: Check whether the dependency catalog has been re-attested within 90 days
+        allowFailure: true
+        task:
+          type: model_method
+          modelIdOrName: falsifier-dependencies-unknown-001
+          methodName: evaluate
+          inputs:
+            evidence:
+              - evidenceId: "evidence-dependencies-known-001"
+                outcome: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.timestamp }}
+                freshnessWindow: "P90D"
+                value: null
+                rawData: null
+  - name: health-checks-absent
+    description: Evaluate falsifier-health-checks-absent-001 against GitHub Contents API evidence
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: evaluate
+        description: Check whether .github/workflows/validate.yml is present in the repository
+        allowFailure: true
+        task:
+          type: model_method
+          modelIdOrName: falsifier-health-checks-absent-001
+          methodName: evaluate
+          inputs:
+            evidence:
+              - evidenceId: "evidence-health-checks-present-001"
+                outcome: ${{ data.latest("evidence-health-checks-present-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-health-checks-present-001", "current").attributes.timestamp }}
+                freshnessWindow: "P1D"
+                value: null
+                rawData: ${{ data.latest("evidence-health-checks-present-001", "current").attributes.rawData }}
+  - name: clients-unknown
+    description: Evaluate falsifier-clients-unknown-001 against the service descriptor attestation timestamp
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: evaluate
+        description: Check whether the client/adopter catalog has been re-attested within 90 days
+        allowFailure: true
+        task:
+          type: model_method
+          modelIdOrName: falsifier-clients-unknown-001
+          methodName: evaluate
+          inputs:
+            evidence:
+              - evidenceId: "evidence-clients-known-001"
+                outcome: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.timestamp }}
+                freshnessWindow: "P90D"
+                value: null
+                rawData: null

--- a/workflows/workflow-7ffc2c4d-9b41-481f-8e94-4aac697e70e3.yaml
+++ b/workflows/workflow-7ffc2c4d-9b41-481f-8e94-4aac697e70e3.yaml
@@ -240,4 +240,18 @@ jobs:
         allowFailure: true
     dependsOn: []
     weight: 0
+  - name: health-checks-present
+    description: Gather CI validation pipeline presence evidence (GitHub Contents API)
+    steps:
+      - name: fetch
+        description: Query GitHub Contents API to confirm validate.yml exists
+        task:
+          type: model_method
+          modelIdOrName: evidence-health-checks-present-001
+          methodName: gather
+          inputs:
+            githubToken: ${{ vault.get(rave-credentials, GITHUB_TOKEN) }}
+        allowFailure: true
+    dependsOn: []
+    weight: 0
 version: 1

--- a/workflows/workflow-adfc9a4a-a667-4f4f-8f98-7d9edee3893d.yaml
+++ b/workflows/workflow-adfc9a4a-a667-4f4f-8f98-7d9edee3893d.yaml
@@ -113,3 +113,15 @@ jobs:
                 nodeType: "claim"
                 status: "active"
                 confidenceScore: ${{ data.latest("confidence-claim-slo-catalog-complete-001", "current").attributes.confidenceScore }}
+              - nodeId: "claim-dependencies-known-001"
+                nodeType: "claim"
+                status: "active"
+                confidenceScore: ${{ data.latest("confidence-claim-dependencies-known-001", "current").attributes.confidenceScore }}
+              - nodeId: "claim-health-checks-present-001"
+                nodeType: "claim"
+                status: "active"
+                confidenceScore: ${{ data.latest("confidence-claim-health-checks-present-001", "current").attributes.confidenceScore }}
+              - nodeId: "claim-clients-known-001"
+                nodeType: "claim"
+                status: "active"
+                confidenceScore: ${{ data.latest("confidence-claim-clients-known-001", "current").attributes.confidenceScore }}

--- a/workflows/workflow-fd0aacde-a1bc-46d1-bd64-3b1a8c239263.yaml
+++ b/workflows/workflow-fd0aacde-a1bc-46d1-bd64-3b1a8c239263.yaml
@@ -407,3 +407,69 @@ jobs:
                 qualityScore: 0.90
                 failureReason: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.failureReason }}
                 remediation: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.remediation }}
+  - name: dependencies-known
+    description: Recompute confidence for claim-dependencies-known-001
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: compute
+        description: Apply RAVE decay formula with latest dependency catalog attestation
+        allowFailure: true
+        task:
+          type: model_method
+          modelIdOrName: confidence-claim-dependencies-known-001
+          methodName: compute
+          inputs:
+            currentStatus: "active"
+            evidence:
+              - evidenceId: "evidence-dependencies-known-001"
+                outcome: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.timestamp }}
+                freshnessWindow: "P90D"
+                qualityScore: 0.85
+                failureReason: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.remediation }}
+  - name: health-checks-present
+    description: Recompute confidence for claim-health-checks-present-001
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: compute
+        description: Apply RAVE decay formula with latest CI health pipeline presence evidence
+        allowFailure: true
+        task:
+          type: model_method
+          modelIdOrName: confidence-claim-health-checks-present-001
+          methodName: compute
+          inputs:
+            currentStatus: "active"
+            evidence:
+              - evidenceId: "evidence-health-checks-present-001"
+                outcome: ${{ data.latest("evidence-health-checks-present-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("evidence-health-checks-present-001", "current").attributes.timestamp }}
+                freshnessWindow: "P1D"
+                qualityScore: 0.90
+                failureReason: ${{ data.latest("evidence-health-checks-present-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("evidence-health-checks-present-001", "current").attributes.remediation }}
+  - name: clients-known
+    description: Recompute confidence for claim-clients-known-001
+    dependsOn: []
+    weight: 0
+    steps:
+      - name: compute
+        description: Apply RAVE decay formula with latest client catalog attestation
+        allowFailure: true
+        task:
+          type: model_method
+          modelIdOrName: confidence-claim-clients-known-001
+          methodName: compute
+          inputs:
+            currentStatus: "active"
+            evidence:
+              - evidenceId: "evidence-clients-known-001"
+                outcome: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.outcome }}
+                timestamp: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.timestamp }}
+                freshnessWindow: "P90D"
+                qualityScore: 0.85
+                failureReason: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.failureReason }}
+                remediation: ${{ data.latest("service-descriptor-rave-swamp-001", "current").attributes.remediation }}


### PR DESCRIPTION
## Summary

Adds four new RAVE claims derived from *Production-Ready Microservices* (Fowler, 2016), each fully wired as a concrete rave-swamp claim. Advances the catalog from 7/50 → 10/50 complete.

| Claim | Status | Falsifier | Evidence |
|---|---|---|---|
| `claim-dependencies-known-001` | active | staleness P90D | descriptor attestation |
| `claim-health-checks-present-001` | active | boolean `$.name == validate.yml` | GitHub Contents API |
| `claim-deprecation-procedure-001` | **draft** | staleness P180D | descriptor attestation |
| `claim-clients-known-001` | active | staleness P90D | descriptor attestation |

Each claim includes: claim + evidence + falsifier YAML, confidence-engine and falsifier-engine model instances, and workflow wiring in all relevant sweeps.

`claim-deprecation-procedure-001` is `draft` — a deprecation procedure doc needs to be written before it can be activated (question wired into `deno task assess` for when it's ready).

`claim-health-checks-present-001` is adapted for a CLI/automation repo: the CI validation pipeline (`validate.yml`) serves as the operational health signal. Evidence is machine-gathered via the GitHub Contents API.

## Test plan

- [ ] `deno task check` passes (no new failures beyond pre-existing stale-confidence claims)
- [ ] `swamp workflow validate` on the four modified workflow files
- [ ] `swamp workflow run gather-all-evidence` picks up the new `health-checks-present` job
- [ ] `swamp workflow run falsifier-sweep` evaluates the three new falsifiers
- [ ] `swamp workflow run confidence-decay-sweep` computes scores for the three active claims
- [ ] `swamp workflow run readiness-check` includes the three active claims in its node list
- [ ] `deno task assess` presents the three new questions (deps, deprecation, clients) when the descriptor becomes stale

🤖 Generated with [Claude Code](https://claude.com/claude-code)